### PR TITLE
[#66] [CHORE] Set up Kover code coverage

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.android.application")
     kotlin("android")
+    id("kover")
 }
 
 android {
@@ -35,6 +36,15 @@ android {
     }
     kotlinOptions {
         jvmTarget = "1.8"
+    }
+    testOptions {
+        unitTests.all {
+            if (it.name != "testDebugUnitTest") {
+                it.extensions.configure(kotlinx.kover.api.KoverTaskExtension::class) {
+                    isDisabled.set(true)
+                }
+            }
+        }
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,11 +1,31 @@
+buildscript {
+    dependencies {
+        classpath("org.jetbrains.kotlinx:kover:0.6.1")
+    }
+}
+
 plugins {
     //trick: for the same plugin versions in all sub-modules
     id("com.android.application").version("7.4.2").apply(false)
     id("com.android.library").version("7.4.2").apply(false)
+    id("org.jetbrains.kotlinx.kover") version "0.6.1"
     kotlin("android").version("1.8.0").apply(false)
     kotlin("multiplatform").version("1.8.0").apply(false)
 }
 
 tasks.register("clean", Delete::class) {
     delete(rootProject.buildDir)
+}
+
+koverMerged {
+    enable()
+
+    filters {
+        classes {
+            excludes += listOf(
+                "*.databinding.*",
+                "*.BuildConfig"
+            )
+        }
+    }
 }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     kotlin("multiplatform")
     kotlin("native.cocoapods")
     id("com.android.library")
+    id("kover")
 }
 
 kotlin {
@@ -63,5 +64,15 @@ android {
     defaultConfig {
         minSdk = 21
         targetSdk = 33
+    }
+
+    testOptions {
+        unitTests.all {
+            if (it.name != "testDebugUnitTest") {
+                it.extensions.configure(kotlinx.kover.api.KoverTaskExtension::class) {
+                    isDisabled.set(true)
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
- Closes #66

## What happened 👀

To run unit tests and generate the code coverage report using the Gradle task as part of the CI/CD workflows, set up Kover.

## Insight 📝

Set up **Kover** following the instructions [here](https://kotlin.github.io/kotlinx-kover/).

## Proof Of Work 📹

![image](https://user-images.githubusercontent.com/8093908/230600065-b28288be-f765-4691-9f17-8e1d0ca7b999.png)

![image](https://user-images.githubusercontent.com/8093908/230600116-01607e8c-7b08-4b77-be68-810372b2410d.png)

![image](https://user-images.githubusercontent.com/8093908/230600160-2a022cbd-ca65-48ca-9d91-52dbfc1571de.png)
