### PR TITLE
[#64] [Chore] Set up CI/CD workflow for distributing iOS production app to AppStore

### DIFF
--- a/.github/workflows/release_ios_appstore.yml
+++ b/.github/workflows/release_ios_appstore.yml
@@ -1,0 +1,115 @@
+name: Release iOS Production App to AppStore Connect
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  shared_test:
+      name: Running tests in Shared module
+      runs-on: ubuntu-latest
+      defaults:
+        run:
+          working-directory: shared
+      steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Java JDK
+        uses: actions/setup-java@v2.1.0
+        with:
+          distribution: 'adopt'
+          java-version: '11'
+
+      - name: Running tests
+        run: |
+          cd ..
+          ./gradlew clean shared:test
+
+  ios_release_production:
+    name: Automatic Release iOS Production App to AppStore Connect
+    runs-on: macos-latest
+    defaults:
+        run:
+          working-directory: iosApp
+    steps:
+      - name: Set up JAVA 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install SSH key - For accessing match repo
+        uses: webfactory/ssh-agent@v0.7.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+      - uses: actions/cache@v3
+        id: bunlderCache
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-
+
+      - name: Bundle install
+        run: bundle install --path vendor/bundle
+
+      - name: Paste Google-Info.plist from .secrets
+        env:
+          IOS_GOOGLE_SERVICE_INFO_PRODUCTION: ${{ secrets.IOS_PRODUCTION_GOOGLE_INFO_PLIST }}
+        run: |
+          mkdir -p PhongKMMIC/Configurations/Plists/GoogleService/Production
+          echo $IOS_GOOGLE_SERVICE_INFO_PRODUCTION | base64 --decode > ./PhongKMMIC/Configurations/Plists/GoogleService/Production/GoogleService-Info.plist
+
+      - name: Cache Gradle
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches/modules-*
+            ~/.gradle/caches/jars-*
+            ~/.gradle/caches/build-cache-*
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Generate KMM frameworks for Cocoapods
+        run: |
+          cd ..
+          ./gradlew generateDummyFramework
+
+      - name: Cache Pods
+        uses: actions/cache@v3
+        id: cocoapodCache
+        with:
+          path: Pods
+          key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-
+
+      - name: Install Pods Dependencies
+        run: bundle exec pod install
+
+      - name: Build and Test
+        run: bundle exec fastlane buildAndTest
+
+      - name: Sync AppStore Production Signing
+        env:
+          CI: true
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+        run: bundle exec fastlane syncAppStoreCodeSigning
+
+      - name: Build and Upload to AppStore Connect
+        env:
+          APPSTORE_CONNECT_API_KEY: ${{ secrets.APPSTORE_CONNECT_API_KEY }}
+          API_KEY_ID: ${{ secrets.APPSTORE_CONNECT_API_KEY_ID }}
+          ISSUER_ID: ${{ secrets.APPSTORE_CONNECT_ISSUER_ID }}
+          FIREBASE_CLI_TOKEN: ${{ secrets.FIREBASE_CLI_TOKEN }}
+        run: bundle exec fastlane buildAndUploadToAppStore
+

--- a/.github/workflows/release_ios_staging.yml
+++ b/.github/workflows/release_ios_staging.yml
@@ -2,8 +2,8 @@ name: Release iOS Staging App to Firebase
 
 on:
   push:
-    branches:
-      - develop
+    branches: [develop, chore/#5-set-up-release-firebase-staging-workflow]
+
 
 jobs:
   shared_test:

--- a/.github/workflows/release_ios_staging.yml
+++ b/.github/workflows/release_ios_staging.yml
@@ -2,8 +2,11 @@ name: Release iOS Staging App to Firebase
 
 on:
   push:
-    branches: [develop, chore/#5-set-up-release-firebase-staging-workflow]
+    branches: [develop]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   shared_test:
@@ -33,11 +36,6 @@ jobs:
         run:
           working-directory: iosApp
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          access_token: ${{ github.token }}
-
       - name: Set up JAVA 11
         uses: actions/setup-java@v3
         with:
@@ -68,7 +66,6 @@ jobs:
           IOS_GOOGLE_SERVICE_INFO_STAGING: ${{ secrets.IOS_STAGING_GOOGLE_INFO_PLIST }}
         run: |
           mkdir -p PhongKMMIC/Configurations/Plists/GoogleService/Staging
-          touch PhongKMMIC/Configurations/Plists/GoogleService/Staging/GoogleService-Info.plist
           echo $IOS_GOOGLE_SERVICE_INFO_STAGING | base64 --decode > ./PhongKMMIC/Configurations/Plists/GoogleService/Staging/GoogleService-Info.plist
 
       - name: Cache Gradle
@@ -99,8 +96,8 @@ jobs:
       - name: Install Pods Dependencies
         run: bundle exec pod install
 
-      # - name: Build and Test
-      #   run: bundle exec fastlane buildAndTest
+      - name: Build and Test
+        run: bundle exec fastlane buildAndTest
 
       - name: Sync Addhoc Staging Signing
         env:

--- a/.github/workflows/release_ios_staging.yml
+++ b/.github/workflows/release_ios_staging.yml
@@ -1,0 +1,112 @@
+name: Release iOS Staging App to Firebase
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  shared_test:
+      name: Running tests in Shared module
+      runs-on: ubuntu-latest
+      defaults:
+        run:
+          working-directory: shared
+      steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Java JDK
+        uses: actions/setup-java@v2.1.0
+        with:
+          distribution: 'adopt'
+          java-version: '11'
+
+      - name: Running tests
+        run: |
+          cd ..
+          ./gradlew clean shared:test
+
+  ios_release_staging:
+    name: Automatic Release iOS Staging App to Firebase
+    runs-on: macos-latest
+    defaults:
+        run:
+          working-directory: iosApp
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+        with:
+          access_token: ${{ github.token }}
+
+      - name: Set up JAVA 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+
+      - name: Install SSH key - For accessing match repo
+        uses: webfactory/ssh-agent@v0.5.4
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - uses: actions/cache@v3
+        id: bunlderCache
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-
+
+      - name: Bundle install
+        run: bundle install --path vendor/bundle
+
+      - name: Paste Google-Info.plist from .secrets
+        env:
+          IOS_GOOGLE_SERVICE_INFO_STAGING: ${{ secrets.IOS_STAGING_GOOGLE_INFO_PLIST }}
+        run: |
+          mkdir -p PhongKMMIC/Configurations/Plists/GoogleService/Staging
+          touch PhongKMMIC/Configurations/Plists/GoogleService/Staging/GoogleService-Info.plist
+          echo $IOS_GOOGLE_SERVICE_INFO_STAGING | base64 --decode > ./PhongKMMIC/Configurations/Plists/GoogleService/Staging/GoogleService-Info.plist
+
+      - name: Cache Gradle
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches/modules-*
+            ~/.gradle/caches/jars-*
+            ~/.gradle/caches/build-cache-*
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Generate KMM frameworks for Cocoapods
+        run: |
+          cd ..
+          ./gradlew generateDummyFramework
+
+      - name: Cache Pods
+        uses: actions/cache@v3
+        id: cocoapodCache
+        with:
+          path: Pods
+          key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-
+
+      - name: Install Pods Dependencies
+        run: bundle exec pod install
+
+      - name: Build and Test
+        run: bundle exec fastlane buildAndTest
+
+      - name: Sync Addhoc Staging Signing
+        run: bundle exec fastlane syncAdHocStagingCodeSigning --verbose
+
+      - name: Build and Upload to Firebase
+        env:
+          FIREBASE_CLI_TOKEN: ${{ secrets.FIREBASE_CLI_TOKEN }}
+        run: bundle exec fastlane buildStagingAndUploadToFirebase
+

--- a/.github/workflows/release_ios_staging.yml
+++ b/.github/workflows/release_ios_staging.yml
@@ -44,13 +44,13 @@ jobs:
           distribution: 'zulu'
           java-version: '11'
 
-      - name: Install SSH key - For accessing match repo
-        uses: webfactory/ssh-agent@v0.5.4
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Install SSH key - For accessing match repo
+        uses: webfactory/ssh-agent@v0.7.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - uses: actions/cache@v3
         id: bunlderCache
@@ -99,11 +99,14 @@ jobs:
       - name: Install Pods Dependencies
         run: bundle exec pod install
 
-      - name: Build and Test
-        run: bundle exec fastlane buildAndTest
+      # - name: Build and Test
+      #   run: bundle exec fastlane buildAndTest
 
       - name: Sync Addhoc Staging Signing
-        run: bundle exec fastlane syncAdHocStagingCodeSigning --verbose
+        env:
+          CI: true
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+        run: bundle exec fastlane syncAdHocStagingCodeSigning
 
       - name: Build and Upload to Firebase
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,4 @@ buildSrc/src/main/kotlin/appPackage/BuildKonfig.kt
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
+.secrets

--- a/iosApp/PhongKMMIC.xcodeproj/project.pbxproj
+++ b/iosApp/PhongKMMIC.xcodeproj/project.pbxproj
@@ -1017,6 +1017,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				MARKETING_VERSION = 0.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "${PRODUCT_BUNDLE_IDENTIFIER}";
 				PRODUCT_NAME = PhongKMMIC;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1359,6 +1360,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				MARKETING_VERSION = 0.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "${PRODUCT_BUNDLE_IDENTIFIER}";
 				PRODUCT_NAME = PhongKMMIC;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1438,6 +1440,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				MARKETING_VERSION = 0.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "${PRODUCT_BUNDLE_IDENTIFIER}";
 				PRODUCT_NAME = PhongKMMIC;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1469,6 +1472,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				MARKETING_VERSION = 0.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "${PRODUCT_BUNDLE_IDENTIFIER}";
 				PRODUCT_NAME = PhongKMMIC;
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/iosApp/PhongKMMIC/Configurations/Plists/Info.plist
+++ b/iosApp/PhongKMMIC/Configurations/Plists/Info.plist
@@ -15,17 +15,17 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>0.1.0</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>0.1.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>
 	</array>
-    <key>UILaunchStoryboardName</key>
-    <string>LaunchScreen</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>


### PR DESCRIPTION
- Close #64

## What happened 👀

- Create `release_ios_appstore` workflow for releasing the iOS production app to AppStore Connect

## Insight 📝

When a branch gets merged into the `main` branch, a workflow will be automatically triggered to build and upload the binary to AppStore Connect.

## Proof Of Work 📹

![Screenshot 2023-04-14 at 14 00 42](https://user-images.githubusercontent.com/22606906/231968065-63f87d32-bae7-420f-b042-9b018722a1e1.png)

