### PR TITLE
[Chore] Bump app version to 0.3.0

### DIFF
--- a/iosApp/PhongKMMIC.xcodeproj/project.pbxproj
+++ b/iosApp/PhongKMMIC.xcodeproj/project.pbxproj
@@ -1009,7 +1009,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.2.0;
+				MARKETING_VERSION = 0.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "${PRODUCT_BUNDLE_IDENTIFIER}";
 				PRODUCT_NAME = PhongKMMIC;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1352,7 +1352,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.2.0;
+				MARKETING_VERSION = 0.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "${PRODUCT_BUNDLE_IDENTIFIER}";
 				PRODUCT_NAME = PhongKMMIC;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1432,7 +1432,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.2.0;
+				MARKETING_VERSION = 0.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "${PRODUCT_BUNDLE_IDENTIFIER}";
 				PRODUCT_NAME = PhongKMMIC;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1464,7 +1464,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.2.0;
+				MARKETING_VERSION = 0.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "${PRODUCT_BUNDLE_IDENTIFIER}";
 				PRODUCT_NAME = PhongKMMIC;
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
## What happened 👀

- Change the app's marketing version to 0.3.0

## Insight 📝

When moving to the 3rd sprint, we need to bump the app version to 0.3.0

## Proof Of Work 📹

![Screenshot 2023-04-26 at 09 12 01](https://user-images.githubusercontent.com/22606906/234448472-79e0f6dd-bc23-4b39-8974-4cc636d10f3d.png)


