### PR TITLE
[CHORE] Bump Android version to 0.3.0

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -6,13 +6,13 @@ plugins {
 
 android {
     namespace = "co.nimblehq.avishek.phong.kmmic.android"
-    compileSdk = 33
+    compileSdk = Version.ANDROID_COMPILE_SDK_VERSION
     defaultConfig {
         applicationId = "co.nimblehq.avishek.phong.kmmic.android"
-        minSdk = 23
-        targetSdk = 33
-        versionCode = 1
-        versionName = "1.0"
+        minSdk = Version.ANDROID_MIN_SDK_VERSION
+        targetSdk = Version.ANDROID_TARGET_SDK_VERSION
+        versionCode = Version.ANDROID_VERSION_CODE
+        versionName = Version.ANDROID_VERSION_NAME
     }
     buildFeatures {
         compose = true

--- a/buildSrc/src/main/kotlin/appPackage/Version.kt
+++ b/buildSrc/src/main/kotlin/appPackage/Version.kt
@@ -1,4 +1,11 @@
 object Version {
+    const val ANDROID_COMPILE_SDK_VERSION = 33
+    const val ANDROID_MIN_SDK_VERSION = 23
+    const val ANDROID_TARGET_SDK_VERSION = 33
+
+    const val ANDROID_VERSION_CODE = 2
+    const val ANDROID_VERSION_NAME = "0.3.0"
+
     const val JSON_API = "0.1.0"
     const val BUILD_KONFIG = "0.13.3"
     const val KTOR = "2.1.1"


### PR DESCRIPTION
## What happened 👀

Bump the Android app version to 0.3.0.

## Insight 📝

- Moved the version numbers to `Version.kt` file and set the version to `0.3.0`.

## Proof Of Work 📹

N/A.

