### PR TITLE
[#11] [KMM] [Backend] As a user, I can see the available surveys

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,7 @@ buildscript {
         classpath(Dependency.BUILD_KONFIG)
         classpath(Dependency.KOVER)
         classpath(Dependency.GOOGLE_SERVICES)
+        classpath(Dependency.REALM_GRADLE_PLUGIN)
     }
 }
 

--- a/buildSrc/src/main/kotlin/appPackage/Dependency.kt
+++ b/buildSrc/src/main/kotlin/appPackage/Dependency.kt
@@ -87,4 +87,8 @@ object Dependency {
 
     // Bom
     const val BOM = "org.jetbrains.kotlin:kotlin-bom:${Version.BOM}"
+
+    // Realm
+    const val REALM_GRADLE_PLUGIN = "io.realm.kotlin:gradle-plugin:${Version.REALM}"
+    const val REALM_LIBRARY_BASE = "io.realm.kotlin:library-base:${Version.REALM}"
 }

--- a/buildSrc/src/main/kotlin/appPackage/Plugin.kt
+++ b/buildSrc/src/main/kotlin/appPackage/Plugin.kt
@@ -19,4 +19,5 @@ object Plugin {
     const val KSP = "com.google.devtools.ksp"
 
     const val MOKO_RESOURCES = "dev.icerock.mobile.multiplatform-resources"
+    const val REALM = "io.realm.kotlin"
 }

--- a/buildSrc/src/main/kotlin/appPackage/Version.kt
+++ b/buildSrc/src/main/kotlin/appPackage/Version.kt
@@ -33,6 +33,7 @@ object Version {
     const val ESPRESSO_CORE = "3.4.0"
     const val MOCKK = "1.13.3"
     const val ROBOLECTRIC = "4.9.1"
+    const val REALM = "1.3.0"
 
     // COMPOSE
     const val COMPOSE = "1.3.2"

--- a/iosApp/PhongKMMIC/Sources/Presentation/Modules/Home/HomeView.swift
+++ b/iosApp/PhongKMMIC/Sources/Presentation/Modules/Home/HomeView.swift
@@ -6,9 +6,14 @@
 //  Copyright © 2023 Nimble. All rights reserved.
 //
 
+import Factory
 import SwiftUI
+import shared
 
 struct HomeView: View {
+
+    // TODO: Remove this in the integration story
+    @Injected(\.homeViewModel) private var viewModel
 
     @State private var isLoading = true
 
@@ -47,6 +52,9 @@ struct HomeView: View {
                 }
             }
             .onAppear {
+                // TODO: Remove this in the integration story
+                viewModel.fetchData()
+
                 Timer.scheduledTimer(withTimeInterval: 2.0, repeats: false) { _ in
                     isLoading.toggle()
                 }

--- a/iosApp/PhongKMMIC/Sources/Supports/Extensions/DI/Container.swift
+++ b/iosApp/PhongKMMIC/Sources/Supports/Extensions/DI/Container.swift
@@ -18,4 +18,8 @@ extension Container {
     var logInViewModel: Factory<LogInViewModel> {
         Factory(self) { KoinApplication.inject(\.logInViewModel) }
     }
+
+    var homeViewModel: Factory<HomeViewModel> {
+        Factory(self) { KoinApplication.inject(\.homeViewModel) }
+    }
 }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -12,6 +12,7 @@ plugins {
     id(Plugin.KOVER)
     id(Plugin.KSP).version(Version.KSP)
     id(Plugin.NATIVE_COROUTINES).version(Version.NATIVE_COROUTINES_KOTLIN)
+    id(Plugin.REALM)
 }
 
 kotlin {
@@ -67,6 +68,9 @@ kotlin {
 
                 // Koin
                 implementation(Dependency.KOIN_CORE)
+
+                // Realm
+                implementation(Dependency.REALM_LIBRARY_BASE)
             }
         }
         val commonTest by getting {

--- a/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/Endpoint.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/Endpoint.kt
@@ -3,4 +3,5 @@ package co.nimblehq.avishek.phong.kmmic
 object Endpoint {
 
     const val OAUTH_TOKEN = "api/v1/oauth/token"
+    const val SURVEYS = "api/v1/surveys"
 }

--- a/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/data/local/datasource/SurveyLocalDataSource.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/data/local/datasource/SurveyLocalDataSource.kt
@@ -8,7 +8,7 @@ import io.realm.kotlin.ext.query
 interface SurveyLocalDataSource {
     fun saveSurveys(surveys: List<SurveyRealmObject>)
     fun getSurveys(): List<SurveyRealmObject>
-    fun removeAllSurvey()
+    fun removeAllSurveys()
 }
 
 class SurveyLocalDataSourceImpl(private val realm: Realm) : SurveyLocalDataSource {
@@ -25,7 +25,7 @@ class SurveyLocalDataSourceImpl(private val realm: Realm) : SurveyLocalDataSourc
         return realm.query<SurveyRealmObject>().find()
     }
 
-    override fun removeAllSurvey() {
+    override fun removeAllSurveys() {
         realm.writeBlocking {
             val surveys = query<SurveyRealmObject>().find()
             delete(surveys)

--- a/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/data/local/datasource/SurveyLocalDataSource.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/data/local/datasource/SurveyLocalDataSource.kt
@@ -1,0 +1,34 @@
+package co.nimblehq.avishek.phong.kmmic.data.local.datasource
+
+import co.nimblehq.avishek.phong.kmmic.data.local.model.SurveyRealmObject
+import io.realm.kotlin.Realm
+import io.realm.kotlin.UpdatePolicy
+import io.realm.kotlin.ext.query
+
+interface SurveyLocalDataSource {
+    fun saveSurveys(surveys: List<SurveyRealmObject>)
+    fun getSurveys(): List<SurveyRealmObject>
+    fun removeAllSurvey()
+}
+
+class SurveyLocalDataSourceImpl(private val realm: Realm) : SurveyLocalDataSource {
+
+    override fun saveSurveys(surveys: List<SurveyRealmObject>) {
+        realm.writeBlocking {
+            surveys.forEach {
+                copyToRealm(it, UpdatePolicy.ALL)
+            }
+        }
+    }
+
+    override fun getSurveys(): List<SurveyRealmObject> {
+        return realm.query<SurveyRealmObject>().find()
+    }
+
+    override fun removeAllSurvey() {
+        realm.writeBlocking {
+            val surveys = query<SurveyRealmObject>().find()
+            delete(surveys)
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/data/local/model/SurveyRealmObject.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/data/local/model/SurveyRealmObject.kt
@@ -1,0 +1,42 @@
+package co.nimblehq.avishek.phong.kmmic.data.local.model
+
+import co.nimblehq.avishek.phong.kmmic.domain.model.Survey
+import io.realm.kotlin.types.RealmObject
+import io.realm.kotlin.types.annotations.PrimaryKey
+
+open class SurveyRealmObject : RealmObject {
+
+    @PrimaryKey
+    var id: String = ""
+    var type: String = ""
+    var title: String = ""
+    var description: String = ""
+    var isActive: Boolean = false
+    var coverImageUrl: String = ""
+
+    constructor(
+        id: String,
+        type: String,
+        title: String,
+        description: String,
+        isActive: Boolean,
+        coverImageUrl: String
+    ) : this() {
+        this.id = id
+        this.type = type
+        this.title = title
+        this.description = description
+        this.isActive = isActive
+        this.coverImageUrl = coverImageUrl
+    }
+
+    constructor()
+}
+
+fun SurveyRealmObject.toSurvey() = Survey(
+    id,
+    title,
+    description,
+    isActive,
+    coverImageUrl,
+)

--- a/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/data/local/realm/Realm.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/data/local/realm/Realm.kt
@@ -1,0 +1,10 @@
+package co.nimblehq.avishek.phong.kmmic.data.local.realm
+
+import co.nimblehq.avishek.phong.kmmic.data.local.model.SurveyRealmObject
+import io.realm.kotlin.Realm
+import io.realm.kotlin.RealmConfiguration
+
+val realm: Realm by lazy {
+    val configuration = RealmConfiguration.create(schema = setOf(SurveyRealmObject::class))
+    Realm.open(configuration)
+}

--- a/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/data/remote/ApiClient.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/data/remote/ApiClient.kt
@@ -91,6 +91,8 @@ class ApiClient(
         }
     }
 
+
+
     inline fun <reified T, reified P> responseBody(
         path: String,
         httpMethod: HttpMethod,
@@ -101,7 +103,34 @@ class ApiClient(
             method = httpMethod
             setBody(requestBody)
         }
+        return getResponseBody(requestBuilder)
+    }
 
+    inline fun <reified T, reified P> responseBodyWithParams(
+        path: String,
+        httpMethod: HttpMethod,
+        queryParams: P
+    ): Flow<T> {
+        val requestBuilder = HttpRequestBuilder().apply {
+            path(path)
+            method = httpMethod
+            setQueryParameters(queryParams)
+        }
+        return getResponseBody(requestBuilder)
+    }
+
+    inline fun <reified T> responseBody(
+        path: String,
+        httpMethod: HttpMethod
+    ): Flow<T> {
+        val requestBuilder = HttpRequestBuilder().apply {
+            path(path)
+            method = httpMethod
+        }
+        return getResponseBody(requestBuilder)
+    }
+
+    inline fun <reified T> getResponseBody(requestBuilder: HttpRequestBuilder): Flow<T> {
         return flow {
             val body = httpClient.request(
                 requestBuilder.apply {
@@ -128,7 +157,10 @@ class ApiClient(
             method = httpMethod
             setBody(requestBody)
         }
+        return getEmptyResponseBody(requestBuilder)
+    }
 
+    fun getEmptyResponseBody(requestBuilder: HttpRequestBuilder): Flow<Unit> {
         return flow {
             val body = httpClient.request(
                 requestBuilder.apply {

--- a/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/data/remote/ApiClient.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/data/remote/ApiClient.kt
@@ -91,8 +91,6 @@ class ApiClient(
         }
     }
 
-
-
     inline fun <reified T, reified P> responseBody(
         path: String,
         httpMethod: HttpMethod,

--- a/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/data/remote/datasource/SurveyRemoteDataSource.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/data/remote/datasource/SurveyRemoteDataSource.kt
@@ -1,0 +1,19 @@
+package co.nimblehq.avishek.phong.kmmic.data.remote.datasource
+
+import co.nimblehq.avishek.phong.kmmic.Endpoint
+import co.nimblehq.avishek.phong.kmmic.data.remote.ApiClient
+import co.nimblehq.avishek.phong.kmmic.data.remote.model.SurveyApiModel
+import co.nimblehq.avishek.phong.kmmic.data.remote.param.GetSurveysQueryParam
+import io.ktor.http.HttpMethod
+import kotlinx.coroutines.flow.Flow
+
+interface SurveyRemoteDataSource {
+    fun getSurveys(params: GetSurveysQueryParam): Flow<List<SurveyApiModel>>
+}
+
+class SurveyRemoteDataSourceImpl(private val apiClient: ApiClient) : SurveyRemoteDataSource {
+
+    override fun getSurveys(params: GetSurveysQueryParam): Flow<List<SurveyApiModel>> {
+        return apiClient.responseBodyWithParams(Endpoint.SURVEYS, HttpMethod.Get, params)
+    }
+}

--- a/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/data/remote/model/SurveyApiModel.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/data/remote/model/SurveyApiModel.kt
@@ -1,0 +1,39 @@
+package co.nimblehq.avishek.phong.kmmic.data.remote.model
+
+import co.nimblehq.avishek.phong.kmmic.data.local.model.SurveyRealmObject
+import co.nimblehq.avishek.phong.kmmic.domain.model.Survey
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SurveyApiModel(
+    @SerialName("id")
+    val id: String,
+    @SerialName("type")
+    val type: String,
+    @SerialName("title")
+    val title: String,
+    @SerialName("description")
+    val description: String,
+    @SerialName("is_active")
+    val isActive: Boolean,
+    @SerialName("cover_image_url")
+    val coverImageUrl: String,
+)
+
+fun SurveyApiModel.toSurvey() = Survey(
+    id,
+    title,
+    description,
+    isActive,
+    coverImageUrl,
+)
+
+fun SurveyApiModel.toSurveyRealmObject() = SurveyRealmObject(
+    id = id,
+    type = type,
+    title = title,
+    description = description,
+    isActive = isActive,
+    coverImageUrl = coverImageUrl
+)

--- a/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/data/remote/param/GetSurveysQueryParam.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/data/remote/param/GetSurveysQueryParam.kt
@@ -1,0 +1,12 @@
+package co.nimblehq.avishek.phong.kmmic.data.remote.param
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class GetSurveysQueryParam(
+    @SerialName("page[number]")
+    val pageNumber: Int,
+    @SerialName("page[size]")
+    val pageSize: Int
+)

--- a/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/data/repository/SurveyRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/data/repository/SurveyRepositoryImpl.kt
@@ -26,7 +26,7 @@ class SurveyRepositoryImpl(
     ): Flow<List<Survey>> {
         return flow {
             if (isForceLatestData) {
-                surveyLocalDataSource.removeAllSurvey()
+                surveyLocalDataSource.removeAllSurveys()
             } else if (pageNumber == FIRST_PAGE_NUMBER) {
                 val localSurveys = surveyLocalDataSource.getSurveys().map { it.toSurvey() }
                 if (localSurveys.isNotEmpty()) {

--- a/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/data/repository/SurveyRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/data/repository/SurveyRepositoryImpl.kt
@@ -1,0 +1,48 @@
+package co.nimblehq.avishek.phong.kmmic.data.repository
+
+import co.nimblehq.avishek.phong.kmmic.data.local.datasource.SurveyLocalDataSource
+import co.nimblehq.avishek.phong.kmmic.data.local.model.toSurvey
+import co.nimblehq.avishek.phong.kmmic.data.remote.datasource.SurveyRemoteDataSource
+import co.nimblehq.avishek.phong.kmmic.data.remote.model.toSurvey
+import co.nimblehq.avishek.phong.kmmic.data.remote.model.toSurveyRealmObject
+import co.nimblehq.avishek.phong.kmmic.data.remote.param.GetSurveysQueryParam
+import co.nimblehq.avishek.phong.kmmic.domain.model.Survey
+import co.nimblehq.avishek.phong.kmmic.domain.repository.SurveyRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.last
+
+private const val FIRST_PAGE_NUMBER = 1
+
+class SurveyRepositoryImpl(
+    private val surveyRemoteDataSource: SurveyRemoteDataSource,
+    private val surveyLocalDataSource: SurveyLocalDataSource
+) : SurveyRepository {
+
+    override fun getSurveys(
+        pageNumber: Int,
+        pageSize: Int,
+        isForceLatestData: Boolean
+    ): Flow<List<Survey>> {
+        return flow {
+            if (isForceLatestData) {
+                surveyLocalDataSource.removeAllSurvey()
+            } else if (pageNumber == FIRST_PAGE_NUMBER) {
+                val localSurveys = surveyLocalDataSource.getSurveys().map { it.toSurvey() }
+                if (localSurveys.isNotEmpty()) {
+                    emit(localSurveys)
+                }
+            }
+
+            val apiSurveys = surveyRemoteDataSource
+                .getSurveys(GetSurveysQueryParam(pageNumber, pageSize))
+                .last()
+
+            val latestSurveys = apiSurveys.map { it.toSurvey() }
+
+            emit(latestSurveys)
+
+            surveyLocalDataSource.saveSurveys(apiSurveys.map { it.toSurveyRealmObject() })
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/di/extension/Start.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/di/extension/Start.kt
@@ -1,6 +1,7 @@
 package co.nimblehq.avishek.phong.kmmic.di.extension
 
 import co.nimblehq.avishek.phong.kmmic.di.initKoin
+import co.nimblehq.avishek.phong.kmmic.presentation.module.HomeViewModel
 import co.nimblehq.avishek.phong.kmmic.presentation.module.LogInViewModel
 import co.nimblehq.avishek.phong.kmmic.presentation.module.SplashViewModel
 import org.koin.core.Koin
@@ -11,4 +12,6 @@ fun KoinApplication.Companion.start(): KoinApplication = initKoin()
 val Koin.splashViewModel: SplashViewModel
     get() = get()
 val Koin.logInViewModel: LogInViewModel
+    get() = get()
+val Koin.homeViewModel: HomeViewModel
     get() = get()

--- a/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/di/module/LocalModule.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/di/module/LocalModule.kt
@@ -1,10 +1,13 @@
 package co.nimblehq.avishek.phong.kmmic.di.module
 
 import co.nimblehq.avishek.phong.kmmic.data.local.datasource.*
+import co.nimblehq.avishek.phong.kmmic.data.local.realm.realm
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
 import org.koin.dsl.module
 
 val localModule = module {
+    single { realm }
     singleOf(::TokenLocalDataSourceImpl) bind TokenLocalDataSource::class
+    singleOf(::SurveyLocalDataSourceImpl) bind SurveyLocalDataSource::class
 }

--- a/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/di/module/RemoteModule.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/di/module/RemoteModule.kt
@@ -13,4 +13,5 @@ val remoteModule = module {
     singleOf(::ApiClient)
     single(named(UNAUTHORIZED_API_CLIENT)) { ApiClient(get()) }
     single<TokenRemoteDataSource> { TokenRemoteDataSourceImpl(get(named(UNAUTHORIZED_API_CLIENT))) }
+    singleOf(::SurveyRemoteDataSourceImpl) bind SurveyRemoteDataSource::class
 }

--- a/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/di/module/RepositoryModule.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/di/module/RepositoryModule.kt
@@ -1,11 +1,12 @@
 package co.nimblehq.avishek.phong.kmmic.di.module
 
-import co.nimblehq.avishek.phong.kmmic.domain.repository.AuthenticationRepository
-import co.nimblehq.avishek.phong.kmmic.data.repository.AuthenticationRepositoryImpl
+import co.nimblehq.avishek.phong.kmmic.domain.repository.*
+import co.nimblehq.avishek.phong.kmmic.data.repository.*
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
 import org.koin.dsl.module
 
 val repositoryModule = module {
     singleOf(::AuthenticationRepositoryImpl) bind AuthenticationRepository::class
+    singleOf(::SurveyRepositoryImpl) bind SurveyRepository::class
 }

--- a/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/di/module/UseCaseModule.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/di/module/UseCaseModule.kt
@@ -8,4 +8,5 @@ import org.koin.dsl.module
 val useCaseModule = module {
     singleOf(::CheckLoggedInUseCaseImpl) bind CheckLoggedInUseCase::class
     singleOf(::LogInUseCaseImpl) bind LogInUseCase::class
+    singleOf(::GetSurveysUseCaseImpl) bind GetSurveysUseCase::class
 }

--- a/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/domain/model/Survey.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/domain/model/Survey.kt
@@ -1,0 +1,9 @@
+package co.nimblehq.avishek.phong.kmmic.domain.model
+
+data class Survey (
+    val id: String,
+    val title: String,
+    val description: String,
+    val isActive: Boolean,
+    val coverImageUrl: String
+)

--- a/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/domain/repository/SurveyRepository.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/domain/repository/SurveyRepository.kt
@@ -1,0 +1,8 @@
+package co.nimblehq.avishek.phong.kmmic.domain.repository
+
+import co.nimblehq.avishek.phong.kmmic.domain.model.Survey
+import kotlinx.coroutines.flow.Flow
+
+interface SurveyRepository {
+    fun getSurveys(pageNumber: Int, pageSize: Int, isForceLatestData: Boolean): Flow<List<Survey>>
+}

--- a/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/domain/usecase/GetSurveysUseCase.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/domain/usecase/GetSurveysUseCase.kt
@@ -1,0 +1,22 @@
+package co.nimblehq.avishek.phong.kmmic.domain.usecase
+
+import co.nimblehq.avishek.phong.kmmic.domain.model.Survey
+import co.nimblehq.avishek.phong.kmmic.domain.repository.SurveyRepository
+import kotlinx.coroutines.flow.Flow
+
+interface GetSurveysUseCase {
+    operator fun invoke(pageNumber: Int, pageSize: Int, isForceLatestData: Boolean): Flow<List<Survey>>
+}
+
+class GetSurveysUseCaseImpl(
+    private val surveyRepository: SurveyRepository
+) : GetSurveysUseCase {
+
+    override operator fun invoke(
+        pageNumber: Int,
+        pageSize: Int,
+        isForceLatestData: Boolean
+    ): Flow<List<Survey>> {
+        return surveyRepository.getSurveys(pageNumber, pageSize, isForceLatestData)
+    }
+}

--- a/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/presentation/module/HomeViewModel.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/presentation/module/HomeViewModel.kt
@@ -1,0 +1,54 @@
+package co.nimblehq.avishek.phong.kmmic.presentation.module
+
+import co.nimblehq.avishek.phong.kmmic.domain.model.Survey
+import co.nimblehq.avishek.phong.kmmic.domain.usecase.GetSurveysUseCase
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.update
+
+data class HomeViewState(
+    val isLoading: Boolean
+) {
+    constructor() : this (true)
+}
+
+class HomeViewModel(
+    private val getSurveysUseCase: GetSurveysUseCase
+) : BaseViewModel() {
+
+    private val mutableViewState: MutableStateFlow<HomeViewState> =
+        MutableStateFlow(HomeViewState())
+
+    val viewState: StateFlow<HomeViewState> = mutableViewState
+
+    private var currentPage = 1
+
+    fun fetchData() {
+        getSurveysUseCase(currentPage, 10, isForceLatestData = false)
+            .onStart { setStateLoading() }
+            .catch { emit(listOf()) }
+            .onEach {
+                currentPage++
+                handleFetchSuccess()
+            }
+            .launchIn(viewModelScope)
+    }
+
+    private fun setStateLoading() {
+        mutableViewState.update {
+            HomeViewState(isLoading = true)
+        }
+    }
+
+    private fun handleFetchSuccess() {
+        mutableViewState.update {
+            HomeViewState(isLoading = false)
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/presentation/module/HomeViewModel.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/presentation/module/HomeViewModel.kt
@@ -1,12 +1,9 @@
 package co.nimblehq.avishek.phong.kmmic.presentation.module
 
-import co.nimblehq.avishek.phong.kmmic.domain.model.Survey
 import co.nimblehq.avishek.phong.kmmic.domain.usecase.GetSurveysUseCase
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
@@ -22,17 +19,17 @@ class HomeViewModel(
     private val getSurveysUseCase: GetSurveysUseCase
 ) : BaseViewModel() {
 
-    private val mutableViewState: MutableStateFlow<HomeViewState> =
+    private val _viewState: MutableStateFlow<HomeViewState> =
         MutableStateFlow(HomeViewState())
 
-    val viewState: StateFlow<HomeViewState> = mutableViewState
+    val viewState: StateFlow<HomeViewState> = _viewState
 
     private var currentPage = 1
 
     fun fetchData() {
         getSurveysUseCase(currentPage, 10, isForceLatestData = false)
             .onStart { setStateLoading() }
-            .catch { emit(listOf()) }
+            .catch { emit(emptyList()) }
             .onEach {
                 currentPage++
                 handleFetchSuccess()
@@ -41,13 +38,13 @@ class HomeViewModel(
     }
 
     private fun setStateLoading() {
-        mutableViewState.update {
+        _viewState.update {
             HomeViewState(isLoading = true)
         }
     }
 
     private fun handleFetchSuccess() {
-        mutableViewState.update {
+        _viewState.update {
             HomeViewState(isLoading = false)
         }
     }

--- a/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/presentation/module/HomeViewModel.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/presentation/module/HomeViewModel.kt
@@ -9,6 +9,8 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.update
 
+private const val DEFAULT_PAGE_SIZE = 10
+
 data class HomeViewState(
     val isLoading: Boolean
 ) {
@@ -27,7 +29,7 @@ class HomeViewModel(
     private var currentPage = 1
 
     fun fetchData() {
-        getSurveysUseCase(currentPage, 10, isForceLatestData = false)
+        getSurveysUseCase(currentPage, DEFAULT_PAGE_SIZE, isForceLatestData = false)
             .onStart { setStateLoading() }
             .catch { emit(emptyList()) }
             .onEach {

--- a/shared/src/commonTest/kotlin/co/nimblehq/avishek/phong/kmmic/data.repository/AuthenticationRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/co/nimblehq/avishek/phong/kmmic/data.repository/AuthenticationRepositoryTest.kt
@@ -21,7 +21,7 @@ class AuthenticationRepositoryTest {
     @Mock
     private val mockTokenLocalDataSource = mock(classOf<TokenLocalDataSource>())
     @Mock
-    private  val mockTokenRemoteDataSource = mock(classOf<TokenRemoteDataSource>())
+    private val mockTokenRemoteDataSource = mock(classOf<TokenRemoteDataSource>())
 
     private lateinit var repository: AuthenticationRepository
 

--- a/shared/src/commonTest/kotlin/co/nimblehq/avishek/phong/kmmic/data.repository/SurveyRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/co/nimblehq/avishek/phong/kmmic/data.repository/SurveyRepositoryTest.kt
@@ -5,9 +5,9 @@ import co.nimblehq.avishek.phong.kmmic.data.local.datasource.SurveyLocalDataSour
 import co.nimblehq.avishek.phong.kmmic.data.local.model.SurveyRealmObject
 import co.nimblehq.avishek.phong.kmmic.data.local.model.toSurvey
 import co.nimblehq.avishek.phong.kmmic.data.remote.datasource.SurveyRemoteDataSource
-import co.nimblehq.avishek.phong.kmmic.data.remote.model.SurveyApiModel
 import co.nimblehq.avishek.phong.kmmic.data.remote.model.toSurvey
 import co.nimblehq.avishek.phong.kmmic.domain.repository.SurveyRepository
+import co.nimblehq.avishek.phong.kmmic.helper.MockUtil
 import io.kotest.matchers.shouldBe
 import io.mockative.Mock
 import io.mockative.any
@@ -37,14 +37,6 @@ class SurveyRepositoryTest {
     private val mockThrowable = Throwable("mock")
     private val mockSurveyRealmObject = SurveyRealmObject()
         .apply { id = "id" }
-    private val mockSurveyApiModel = SurveyApiModel(
-        "id",
-        "type",
-        "title",
-        "description",
-        true,
-        "coverImageUrl",
-    )
 
     @BeforeTest
     fun setUp() {
@@ -61,10 +53,10 @@ class SurveyRepositoryTest {
             given(mockSurveyRemoteDataSource)
                 .function(mockSurveyRemoteDataSource::getSurveys)
                 .whenInvokedWith(any())
-                .thenReturn(flowOf(listOf(mockSurveyApiModel)))
+                .thenReturn(flowOf(listOf(MockUtil.mockSurveyApiModel)))
 
-            repository.getSurveys(1, 1, false).first() shouldBe
-                    listOf(mockSurveyApiModel.toSurvey())
+            repository.getSurveys(pageNumber = 1, pageSize = 1, isForceLatestData = false).first() shouldBe
+                    listOf(MockUtil.mockSurveyApiModel.toSurvey())
         }
 
     @Test
@@ -78,11 +70,11 @@ class SurveyRepositoryTest {
             given(mockSurveyRemoteDataSource)
                 .function(mockSurveyRemoteDataSource::getSurveys)
                 .whenInvokedWith(any())
-                .thenReturn(flowOf(listOf(mockSurveyApiModel)))
+                .thenReturn(flowOf(listOf(MockUtil.mockSurveyApiModel)))
 
-            repository.getSurveys(1, 1, false).test {
+            repository.getSurveys(pageNumber = 1, pageSize = 1, isForceLatestData = false).test {
                 this.awaitItem() shouldBe listOf(mockSurveyRealmObject.toSurvey())
-                this.awaitItem() shouldBe listOf(mockSurveyApiModel.toSurvey())
+                this.awaitItem() shouldBe listOf(MockUtil.mockSurveyApiModel.toSurvey())
                 this.awaitComplete()
             }
         }
@@ -98,10 +90,10 @@ class SurveyRepositoryTest {
             given(mockSurveyRemoteDataSource)
                 .function(mockSurveyRemoteDataSource::getSurveys)
                 .whenInvokedWith(any())
-                .thenReturn(flowOf(listOf(mockSurveyApiModel)))
+                .thenReturn(flowOf(listOf(MockUtil.mockSurveyApiModel)))
 
             repository.getSurveys(pageNumber = 1, pageSize = 1, isForceLatestData = true).test {
-                this.awaitItem() shouldBe listOf(mockSurveyApiModel.toSurvey())
+                this.awaitItem() shouldBe listOf(MockUtil.mockSurveyApiModel.toSurvey())
                 this.awaitComplete()
             }
 
@@ -125,7 +117,7 @@ class SurveyRepositoryTest {
                     }
                 )
 
-            repository.getSurveys(1, 1, false).test {
+            repository.getSurveys(pageNumber = 1, pageSize = 1, isForceLatestData = false).test {
                 this.awaitError().message shouldBe mockThrowable.message
             }
         }
@@ -146,7 +138,7 @@ class SurveyRepositoryTest {
                         throw mockThrowable
                     }
                 )
-            repository.getSurveys(1, 1, false).test {
+            repository.getSurveys(pageNumber = 1, pageSize = 1, isForceLatestData = false).test {
                 this.awaitItem() shouldBe listOf(mockSurveyRealmObject.toSurvey())
                 this.awaitError().message shouldBe mockThrowable.message
             }

--- a/shared/src/commonTest/kotlin/co/nimblehq/avishek/phong/kmmic/data.repository/SurveyRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/co/nimblehq/avishek/phong/kmmic/data.repository/SurveyRepositoryTest.kt
@@ -17,7 +17,9 @@ import io.mockative.mock
 import io.mockative.times
 import io.mockative.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -50,25 +52,19 @@ class SurveyRepositoryTest {
     }
 
     @Test
-    fun `when there is no cached data and get surveys is succeeded, it returns surveys one time`() =
+    fun `when there is no cached data and surveys are fetched successfully, it returns surveys one time`() =
         runTest {
             given(mockSurveyLocalDataSource)
                 .function(mockSurveyLocalDataSource::getSurveys)
                 .whenInvoked()
-                .thenReturn(listOf())
+                .thenReturn(emptyList())
             given(mockSurveyRemoteDataSource)
                 .function(mockSurveyRemoteDataSource::getSurveys)
                 .whenInvokedWith(any())
-                .thenReturn(
-                    flow {
-                        emit(listOf(mockSurveyApiModel))
-                    }
-                )
+                .thenReturn(flowOf(listOf(mockSurveyApiModel)))
 
-            repository.getSurveys(1, 1, false).test {
-                this.awaitItem() shouldBe listOf(mockSurveyApiModel.toSurvey())
-                this.awaitComplete()
-            }
+            repository.getSurveys(1, 1, false).first() shouldBe
+                    listOf(mockSurveyApiModel.toSurvey())
         }
 
     @Test
@@ -82,11 +78,7 @@ class SurveyRepositoryTest {
             given(mockSurveyRemoteDataSource)
                 .function(mockSurveyRemoteDataSource::getSurveys)
                 .whenInvokedWith(any())
-                .thenReturn(
-                    flow {
-                        emit(listOf(mockSurveyApiModel))
-                    }
-                )
+                .thenReturn(flowOf(listOf(mockSurveyApiModel)))
 
             repository.getSurveys(1, 1, false).test {
                 this.awaitItem() shouldBe listOf(mockSurveyRealmObject.toSurvey())
@@ -106,18 +98,14 @@ class SurveyRepositoryTest {
             given(mockSurveyRemoteDataSource)
                 .function(mockSurveyRemoteDataSource::getSurveys)
                 .whenInvokedWith(any())
-                .thenReturn(
-                    flow {
-                        emit(listOf(mockSurveyApiModel))
-                    }
-                )
+                .thenReturn(flowOf(listOf(mockSurveyApiModel)))
 
             repository.getSurveys(pageNumber = 1, pageSize = 1, isForceLatestData = true).test {
                 this.awaitItem() shouldBe listOf(mockSurveyApiModel.toSurvey())
                 this.awaitComplete()
             }
 
-            verify(mockSurveyLocalDataSource).invocation { removeAllSurvey() }
+            verify(mockSurveyLocalDataSource).invocation { removeAllSurveys() }
                 .wasInvoked(exactly = 1.times)
         }
 
@@ -127,7 +115,7 @@ class SurveyRepositoryTest {
             given(mockSurveyLocalDataSource)
                 .function(mockSurveyLocalDataSource::getSurveys)
                 .whenInvoked()
-                .thenReturn(listOf())
+                .thenReturn(emptyList())
             given(mockSurveyRemoteDataSource)
                 .function(mockSurveyRemoteDataSource::getSurveys)
                 .whenInvokedWith(any())

--- a/shared/src/commonTest/kotlin/co/nimblehq/avishek/phong/kmmic/data.repository/SurveyRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/co/nimblehq/avishek/phong/kmmic/data.repository/SurveyRepositoryTest.kt
@@ -1,0 +1,166 @@
+package co.nimblehq.avishek.phong.kmmic.data.repository
+
+import app.cash.turbine.test
+import co.nimblehq.avishek.phong.kmmic.data.local.datasource.SurveyLocalDataSource
+import co.nimblehq.avishek.phong.kmmic.data.local.model.SurveyRealmObject
+import co.nimblehq.avishek.phong.kmmic.data.local.model.toSurvey
+import co.nimblehq.avishek.phong.kmmic.data.remote.datasource.SurveyRemoteDataSource
+import co.nimblehq.avishek.phong.kmmic.data.remote.model.SurveyApiModel
+import co.nimblehq.avishek.phong.kmmic.data.remote.model.toSurvey
+import co.nimblehq.avishek.phong.kmmic.domain.repository.SurveyRepository
+import io.kotest.matchers.shouldBe
+import io.mockative.Mock
+import io.mockative.any
+import io.mockative.classOf
+import io.mockative.given
+import io.mockative.mock
+import io.mockative.times
+import io.mockative.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+@ExperimentalCoroutinesApi
+class SurveyRepositoryTest {
+
+    @Mock
+    private val mockSurveyRemoteDataSource = mock(classOf<SurveyRemoteDataSource>())
+    @Mock
+    private val mockSurveyLocalDataSource = mock(classOf<SurveyLocalDataSource>())
+
+    private lateinit var repository: SurveyRepository
+
+    private val mockThrowable = Throwable("mock")
+    private val mockSurveyRealmObject = SurveyRealmObject()
+        .apply { id = "id" }
+    private val mockSurveyApiModel = SurveyApiModel(
+        "id",
+        "type",
+        "title",
+        "description",
+        true,
+        "coverImageUrl",
+    )
+
+    @BeforeTest
+    fun setUp() {
+        repository = SurveyRepositoryImpl(mockSurveyRemoteDataSource, mockSurveyLocalDataSource)
+    }
+
+    @Test
+    fun `when there is no cached data and get surveys is succeeded, it returns surveys one time`() =
+        runTest {
+            given(mockSurveyLocalDataSource)
+                .function(mockSurveyLocalDataSource::getSurveys)
+                .whenInvoked()
+                .thenReturn(listOf())
+            given(mockSurveyRemoteDataSource)
+                .function(mockSurveyRemoteDataSource::getSurveys)
+                .whenInvokedWith(any())
+                .thenReturn(
+                    flow {
+                        emit(listOf(mockSurveyApiModel))
+                    }
+                )
+
+            repository.getSurveys(1, 1, false).test {
+                this.awaitItem() shouldBe listOf(mockSurveyApiModel.toSurvey())
+                this.awaitComplete()
+            }
+        }
+
+    @Test
+    fun `when there is cached data and get surveys is succeeded, it returns cached surveys and surveys from API `() =
+        runTest {
+            given(mockSurveyLocalDataSource)
+                .function(mockSurveyLocalDataSource::getSurveys)
+                .whenInvoked()
+                .thenReturn(listOf(mockSurveyRealmObject))
+
+            given(mockSurveyRemoteDataSource)
+                .function(mockSurveyRemoteDataSource::getSurveys)
+                .whenInvokedWith(any())
+                .thenReturn(
+                    flow {
+                        emit(listOf(mockSurveyApiModel))
+                    }
+                )
+
+            repository.getSurveys(1, 1, false).test {
+                this.awaitItem() shouldBe listOf(mockSurveyRealmObject.toSurvey())
+                this.awaitItem() shouldBe listOf(mockSurveyApiModel.toSurvey())
+                this.awaitComplete()
+            }
+        }
+
+    @Test
+    fun `when force latest data with cached data and get surveys is succeeded, it returns only surveys from API`() =
+        runTest {
+            given(mockSurveyLocalDataSource)
+                .function(mockSurveyLocalDataSource::getSurveys)
+                .whenInvoked()
+                .thenReturn(listOf(mockSurveyRealmObject))
+
+            given(mockSurveyRemoteDataSource)
+                .function(mockSurveyRemoteDataSource::getSurveys)
+                .whenInvokedWith(any())
+                .thenReturn(
+                    flow {
+                        emit(listOf(mockSurveyApiModel))
+                    }
+                )
+
+            repository.getSurveys(pageNumber = 1, pageSize = 1, isForceLatestData = true).test {
+                this.awaitItem() shouldBe listOf(mockSurveyApiModel.toSurvey())
+                this.awaitComplete()
+            }
+
+            verify(mockSurveyLocalDataSource).invocation { removeAllSurvey() }
+                .wasInvoked(exactly = 1.times)
+        }
+
+    @Test
+    fun `when there is no cached data and get surveys is failed, it returns error`() =
+        runTest {
+            given(mockSurveyLocalDataSource)
+                .function(mockSurveyLocalDataSource::getSurveys)
+                .whenInvoked()
+                .thenReturn(listOf())
+            given(mockSurveyRemoteDataSource)
+                .function(mockSurveyRemoteDataSource::getSurveys)
+                .whenInvokedWith(any())
+                .thenReturn(
+                    flow {
+                        throw mockThrowable
+                    }
+                )
+
+            repository.getSurveys(1, 1, false).test {
+                this.awaitError().message shouldBe mockThrowable.message
+            }
+        }
+
+    @Test
+    fun `when there is cached data and get surveys is failed, it returns surveys then an error`() =
+        runTest {
+            given(mockSurveyLocalDataSource)
+                .function(mockSurveyLocalDataSource::getSurveys)
+                .whenInvoked()
+                .thenReturn(listOf(mockSurveyRealmObject))
+
+            given(mockSurveyRemoteDataSource)
+                .function(mockSurveyRemoteDataSource::getSurveys)
+                .whenInvokedWith(any())
+                .thenReturn(
+                    flow {
+                        throw mockThrowable
+                    }
+                )
+            repository.getSurveys(1, 1, false).test {
+                this.awaitItem() shouldBe listOf(mockSurveyRealmObject.toSurvey())
+                this.awaitError().message shouldBe mockThrowable.message
+            }
+        }
+}

--- a/shared/src/commonTest/kotlin/co/nimblehq/avishek/phong/kmmic/domain.usecase/GetSurveysUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/co/nimblehq/avishek/phong/kmmic/domain.usecase/GetSurveysUseCaseTest.kt
@@ -2,15 +2,19 @@ package co.nimblehq.avishek.phong.kmmic.domain.usecase
 
 import co.nimblehq.avishek.phong.kmmic.domain.model.Survey
 import co.nimblehq.avishek.phong.kmmic.domain.repository.SurveyRepository
+import co.nimblehq.avishek.phong.kmmic.helper.MockUtil
 import io.kotest.matchers.shouldBe
 import io.mockative.*
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 
+@ExperimentalCoroutinesApi
 class GetSurveysUseCaseTest {
 
     @Mock
@@ -19,13 +23,6 @@ class GetSurveysUseCaseTest {
     private lateinit var useCase: GetSurveysUseCase
 
     private val mockThrowable = Throwable("mock")
-    private val mockSurvey = Survey(
-        "id",
-        "title",
-        "description",
-        true,
-        "coverImageUrl"
-    )
 
     @BeforeTest
     fun setUp() {
@@ -37,14 +34,10 @@ class GetSurveysUseCaseTest {
         given(mockRepository)
             .function(mockRepository::getSurveys)
             .whenInvokedWith(any(), any(), any())
-            .thenReturn(
-                flow {
-                    emit(listOf(mockSurvey))
-                }
-            )
+            .thenReturn(flowOf(listOf(MockUtil.mockSurvey)))
 
         useCase(1, 1, false).collect {
-            it shouldBe listOf(mockSurvey)
+            it shouldBe listOf(MockUtil.mockSurvey)
         }
     }
 

--- a/shared/src/commonTest/kotlin/co/nimblehq/avishek/phong/kmmic/domain.usecase/GetSurveysUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/co/nimblehq/avishek/phong/kmmic/domain.usecase/GetSurveysUseCaseTest.kt
@@ -1,0 +1,68 @@
+package co.nimblehq.avishek.phong.kmmic.domain.usecase
+
+import co.nimblehq.avishek.phong.kmmic.domain.model.Survey
+import co.nimblehq.avishek.phong.kmmic.domain.repository.SurveyRepository
+import io.kotest.matchers.shouldBe
+import io.mockative.*
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+class GetSurveysUseCaseTest {
+
+    @Mock
+    private val mockRepository = mock(classOf<SurveyRepository>())
+
+    private lateinit var useCase: GetSurveysUseCase
+
+    private val mockThrowable = Throwable("mock")
+    private val mockSurvey = Survey(
+        "id",
+        "title",
+        "description",
+        true,
+        "coverImageUrl"
+    )
+
+    @BeforeTest
+    fun setUp() {
+        useCase = GetSurveysUseCaseImpl(mockRepository)
+    }
+
+    @Test
+    fun `when getSurveys is called successfully, it returns a list of surveys`() = runTest {
+        given(mockRepository)
+            .function(mockRepository::getSurveys)
+            .whenInvokedWith(any(), any(), any())
+            .thenReturn(
+                flow {
+                    emit(listOf(mockSurvey))
+                }
+            )
+
+        useCase(1, 1, false).collect {
+            it shouldBe listOf(mockSurvey)
+        }
+    }
+
+    @Test
+    fun `when getSurveys is called but returns an error, it returns an error`() = runTest {
+        given(mockRepository)
+            .function(mockRepository::getSurveys)
+            .whenInvokedWith(any(), any(), any())
+            .thenReturn(
+                flow {
+                    throw mockThrowable
+                }
+            )
+
+        useCase(1, 1, false)
+            .catch {
+                it.message shouldBe mockThrowable.message
+            }
+            .collect()
+    }
+}

--- a/shared/src/commonTest/kotlin/co/nimblehq/avishek/phong/kmmic/helper/MockUtil.kt
+++ b/shared/src/commonTest/kotlin/co/nimblehq/avishek/phong/kmmic/helper/MockUtil.kt
@@ -1,0 +1,25 @@
+package co.nimblehq.avishek.phong.kmmic.helper
+
+import co.nimblehq.avishek.phong.kmmic.data.remote.model.SurveyApiModel
+import co.nimblehq.avishek.phong.kmmic.domain.model.Survey
+
+
+object MockUtil {
+
+    val mockSurvey = Survey(
+        "id",
+        "title",
+        "description",
+        true,
+        "coverImageUrl"
+    )
+
+    val mockSurveyApiModel = SurveyApiModel(
+        "id",
+        "type",
+        "title",
+        "description",
+        true,
+        "coverImageUrl",
+    )
+}

--- a/shared/src/iosMain/kotlin/co/nimblehq/avishek/phong/kmmic/di/module/ViewModelModule.kt
+++ b/shared/src/iosMain/kotlin/co/nimblehq/avishek/phong/kmmic/di/module/ViewModelModule.kt
@@ -9,4 +9,5 @@ actual val viewModelModule: Module
     get() = module {
         factoryOf(::SplashViewModel)
         factoryOf(::LogInViewModel)
+        factoryOf(::HomeViewModel)
     }


### PR DESCRIPTION
- Close #11

## What happened 👀

- Add Realm to shared module to save surveys locally
- Add `SurveyLocalDataSource` and `SurveyRemoteDataSource` for fetching and saving surveys to the app's local database
- Add `GetSurveysUseCase`
- Add `HomeViewModel` for the testing purpose and integrate task.
- Add unit test

## Insight 📝

When a logged-in user opens the application, we will fetch all the available surveys and show them on the Home screen.

## Proof Of Work 📹

![Screenshot 2023-05-10 at 14 11 14](https://github.com/nimblehq/avishek-phong-kmm-ic/assets/22606906/15ae2d21-e6e8-41d4-8c61-09e56392d4b3)


![Screenshot 2023-05-10 at 14 42 32](https://github.com/nimblehq/avishek-phong-kmm-ic/assets/22606906/0d0eeb82-b380-455a-b387-2a1b9031084c)
