### PR TITLE
[#14] [KMM] [Backend] As a user, I can see my profile details 

### DIFF
--- a/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/Endpoint.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/Endpoint.kt
@@ -4,4 +4,5 @@ object Endpoint {
 
     const val OAUTH_TOKEN = "api/v1/oauth/token"
     const val SURVEYS = "api/v1/surveys"
+    const val USER_PROFILE = "api/v1/me"
 }

--- a/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/data/remote/datasource/UserRemoteDataSource.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/data/remote/datasource/UserRemoteDataSource.kt
@@ -1,0 +1,18 @@
+package co.nimblehq.avishek.phong.kmmic.data.remote.datasource
+
+import co.nimblehq.avishek.phong.kmmic.data.remote.ApiClient
+import co.nimblehq.avishek.phong.kmmic.data.remote.model.UserApiModel
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.http.HttpMethod
+import kotlinx.coroutines.flow.Flow
+
+interface UserRemoteDataSource {
+    fun getProfile(): Flow<UserApiModel>
+}
+
+class UserRemoteDataSourceImpl(private val apiClient: ApiClient) : UserRemoteDataSource {
+
+    override fun getProfile(): Flow<UserApiModel> {
+        return apiClient.responseBody("api/v1/me", HttpMethod.Get)
+    }
+}

--- a/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/data/remote/datasource/UserRemoteDataSource.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/data/remote/datasource/UserRemoteDataSource.kt
@@ -1,5 +1,6 @@
 package co.nimblehq.avishek.phong.kmmic.data.remote.datasource
 
+import co.nimblehq.avishek.phong.kmmic.Endpoint
 import co.nimblehq.avishek.phong.kmmic.data.remote.ApiClient
 import co.nimblehq.avishek.phong.kmmic.data.remote.model.UserApiModel
 import io.ktor.client.request.HttpRequestBuilder
@@ -13,6 +14,6 @@ interface UserRemoteDataSource {
 class UserRemoteDataSourceImpl(private val apiClient: ApiClient) : UserRemoteDataSource {
 
     override fun getProfile(): Flow<UserApiModel> {
-        return apiClient.responseBody("api/v1/me", HttpMethod.Get)
+        return apiClient.responseBody(Endpoint.USER_PROFILE, HttpMethod.Get)
     }
 }

--- a/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/data/remote/model/UserApiModel.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/data/remote/model/UserApiModel.kt
@@ -1,0 +1,25 @@
+package co.nimblehq.avishek.phong.kmmic.data.remote.model
+
+import co.nimblehq.avishek.phong.kmmic.domain.model.User
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class UserApiModel(
+    @SerialName("id")
+    val id: String,
+    @SerialName("type")
+    val type: String,
+    @SerialName("email")
+    val email: String,
+    @SerialName("name")
+    val name: String,
+    @SerialName("avatar_url")
+    val avatarUrl: String
+)
+
+fun UserApiModel.toUser() = User(
+    email,
+    name,
+    avatarUrl
+)

--- a/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/data/repository/UserRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/data/repository/UserRepositoryImpl.kt
@@ -1,0 +1,19 @@
+package co.nimblehq.avishek.phong.kmmic.data.repository
+
+import co.nimblehq.avishek.phong.kmmic.data.remote.datasource.UserRemoteDataSource
+import co.nimblehq.avishek.phong.kmmic.data.remote.model.toUser
+import co.nimblehq.avishek.phong.kmmic.domain.model.User
+import co.nimblehq.avishek.phong.kmmic.domain.repository.UserRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+class UserRepositoryImpl(
+    private val userRemoteDataSource: UserRemoteDataSource
+): UserRepository {
+
+    override fun getProfile(): Flow<User> {
+        return userRemoteDataSource
+            .getProfile()
+            .map { it.toUser() }
+    }
+}

--- a/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/di/module/RemoteModule.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/di/module/RemoteModule.kt
@@ -14,4 +14,5 @@ val remoteModule = module {
     single(named(UNAUTHORIZED_API_CLIENT)) { ApiClient(get()) }
     single<TokenRemoteDataSource> { TokenRemoteDataSourceImpl(get(named(UNAUTHORIZED_API_CLIENT))) }
     singleOf(::SurveyRemoteDataSourceImpl) bind SurveyRemoteDataSource::class
+    singleOf(::UserRemoteDataSourceImpl) bind UserRemoteDataSource::class
 }

--- a/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/di/module/RepositoryModule.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/di/module/RepositoryModule.kt
@@ -9,4 +9,5 @@ import org.koin.dsl.module
 val repositoryModule = module {
     singleOf(::AuthenticationRepositoryImpl) bind AuthenticationRepository::class
     singleOf(::SurveyRepositoryImpl) bind SurveyRepository::class
+    singleOf(::UserRepositoryImpl) bind UserRepository::class
 }

--- a/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/di/module/UseCaseModule.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/di/module/UseCaseModule.kt
@@ -9,4 +9,5 @@ val useCaseModule = module {
     singleOf(::CheckLoggedInUseCaseImpl) bind CheckLoggedInUseCase::class
     singleOf(::LogInUseCaseImpl) bind LogInUseCase::class
     singleOf(::GetSurveysUseCaseImpl) bind GetSurveysUseCase::class
+    singleOf(::GetUserProfileUseCaseImpl) bind GetUserProfileUseCase::class
 }

--- a/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/domain/model/Question.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/domain/model/Question.kt
@@ -1,0 +1,4 @@
+package co.nimblehq.avishek.phong.kmmic.domain.model
+
+class Question {
+}

--- a/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/domain/model/Question.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/domain/model/Question.kt
@@ -1,4 +1,0 @@
-package co.nimblehq.avishek.phong.kmmic.domain.model
-
-class Question {
-}

--- a/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/domain/model/User.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/domain/model/User.kt
@@ -1,0 +1,7 @@
+package co.nimblehq.avishek.phong.kmmic.domain.model
+
+data class User(
+    val email: String,
+    val name: String,
+    val avatarUrl: String
+)

--- a/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/domain/repository/UserRepository.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/domain/repository/UserRepository.kt
@@ -1,0 +1,8 @@
+package co.nimblehq.avishek.phong.kmmic.domain.repository
+
+import co.nimblehq.avishek.phong.kmmic.domain.model.User
+import kotlinx.coroutines.flow.Flow
+
+interface UserRepository {
+    fun getProfile(): Flow<User>
+}

--- a/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/domain/usecase/GetUserProfileUseCase.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/domain/usecase/GetUserProfileUseCase.kt
@@ -13,7 +13,6 @@ class GetUserProfileUseCaseImpl(
 ): GetUserProfileUseCase {
 
     override operator fun invoke(): Flow<User> {
-        return userRepository
-            .getProfile()
+        return userRepository.getProfile()
     }
 }

--- a/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/domain/usecase/GetUserProfileUseCase.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/domain/usecase/GetUserProfileUseCase.kt
@@ -1,0 +1,19 @@
+package co.nimblehq.avishek.phong.kmmic.domain.usecase
+
+import co.nimblehq.avishek.phong.kmmic.domain.model.User
+import co.nimblehq.avishek.phong.kmmic.domain.repository.UserRepository
+import kotlinx.coroutines.flow.Flow
+
+interface GetUserProfileUseCase {
+    operator fun invoke(): Flow<User>
+}
+
+class GetUserProfileUseCaseImpl(
+    private val userRepository: UserRepository
+): GetUserProfileUseCase {
+
+    override operator fun invoke(): Flow<User> {
+        return userRepository
+            .getProfile()
+    }
+}

--- a/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/presentation/module/HomeViewModel.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/presentation/module/HomeViewModel.kt
@@ -39,6 +39,21 @@ class HomeViewModel(
             .launchIn(viewModelScope)
     }
 
+    private fun fetchSurvey(
+        page: Int,
+        pageSize: Int,
+        isForceLatestData: Boolean
+    ): Flow<List<Survey>> {
+        return flow {
+            getSurveysUseCase(page, pageSize, isForceLatestData = false)
+                .catch { emit(listOf()) }
+                .collect {
+                    currentPage = page+1
+                    emit(it)
+                }
+        }
+    }
+
     private fun setStateLoading() {
         _viewState.update {
             HomeViewState(isLoading = true)

--- a/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/presentation/module/HomeViewModel.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/presentation/module/HomeViewModel.kt
@@ -38,13 +38,11 @@ class HomeViewModel(
 
     private var currentPage = 1
 
-
-
     fun fetchData() {
         getProfile()
             .onStart { setStateLoading() }
-            .combine(fetchSurvey(currentPage, 10, false)) { user, surveys ->
-                Pair(user, surveys)
+            .combine(fetchSurvey(currentPage, DEFAULT_PAGE_SIZE, false)) { _, _ ->
+                // TODO: Return values in a tuple
             }
             .catch {
                 // TODO: Handle error in integration story

--- a/shared/src/commonTest/kotlin/co/nimblehq/avishek/phong/kmmic/data.repository/UserRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/co/nimblehq/avishek/phong/kmmic/data.repository/UserRepositoryTest.kt
@@ -4,14 +4,15 @@ import co.nimblehq.avishek.phong.kmmic.data.remote.datasource.UserRemoteDataSour
 import co.nimblehq.avishek.phong.kmmic.data.remote.model.UserApiModel
 import co.nimblehq.avishek.phong.kmmic.data.remote.model.toUser
 import co.nimblehq.avishek.phong.kmmic.domain.repository.UserRepository
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.mockative.Mock
 import io.mockative.classOf
 import io.mockative.given
 import io.mockative.mock
-import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -37,19 +38,13 @@ class UserRepositoryTest {
     }
 
     @Test
-    fun `when getProfile returns success, it returns user`() = runTest {
+    fun `when profile is fetched successfully, it returns user`() = runTest {
         given(mockUserRemoteDataSource)
             .function(mockUserRemoteDataSource::getProfile)
             .whenInvoked()
-            .thenReturn(
-                flow {
-                    emit(mockUser)
-                }
-            )
+            .thenReturn(flowOf(mockUser))
 
-        repository.getProfile().collect {
-            it shouldBe mockUser.toUser()
-        }
+        repository.getProfile().first() shouldBe mockUser.toUser()
     }
 
     @Test
@@ -63,8 +58,8 @@ class UserRepositoryTest {
                 }
             )
 
-        repository.getProfile().catch {
-            it.message shouldBe mockThrowable.message
-        }.collect()
+        shouldThrow<Throwable> {
+            repository.getProfile().first()
+        }
     }
 }

--- a/shared/src/commonTest/kotlin/co/nimblehq/avishek/phong/kmmic/data.repository/UserRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/co/nimblehq/avishek/phong/kmmic/data.repository/UserRepositoryTest.kt
@@ -1,0 +1,70 @@
+package co.nimblehq.avishek.phong.kmmic.data.repository
+
+import co.nimblehq.avishek.phong.kmmic.data.remote.datasource.UserRemoteDataSource
+import co.nimblehq.avishek.phong.kmmic.data.remote.model.UserApiModel
+import co.nimblehq.avishek.phong.kmmic.data.remote.model.toUser
+import co.nimblehq.avishek.phong.kmmic.domain.repository.UserRepository
+import io.kotest.matchers.shouldBe
+import io.mockative.Mock
+import io.mockative.classOf
+import io.mockative.given
+import io.mockative.mock
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+class UserRepositoryTest {
+
+    @Mock
+    private val mockUserRemoteDataSource = mock(classOf<UserRemoteDataSource>())
+    private val mockThrowable = Throwable("mock")
+    private val mockUser = UserApiModel(
+        "id",
+        "type",
+        "phong.d@nimblehq.co",
+        "Phong Vo",
+        "https://www.example.com/image.png"
+    )
+
+    private lateinit var repository: UserRepository
+
+    @BeforeTest
+    fun setUp() {
+        repository = UserRepositoryImpl(mockUserRemoteDataSource)
+    }
+
+    @Test
+    fun `when getProfile returns success, it returns user`() = runTest {
+        given(mockUserRemoteDataSource)
+            .function(mockUserRemoteDataSource::getProfile)
+            .whenInvoked()
+            .thenReturn(
+                flow {
+                    emit(mockUser)
+                }
+            )
+
+        repository.getProfile().collect {
+            it shouldBe mockUser.toUser()
+        }
+    }
+
+    @Test
+    fun `when getProfile return failure, it returns error`() = runTest {
+        given(mockUserRemoteDataSource)
+            .function(mockUserRemoteDataSource::getProfile)
+            .whenInvoked()
+            .thenReturn(
+                flow {
+                    throw mockThrowable
+                }
+            )
+
+        repository.getProfile().catch {
+            it.message shouldBe mockThrowable.message
+        }.collect()
+    }
+}


### PR DESCRIPTION
- Close #14 

## What happened 👀

- Add `UserRemoteDataSource` for fetching user's profile task.
- Add `UserRepository`, `GetUserProfileUseCase`
- Add test cases

## Insight 📝

When a user is landed on the Home screen, there is a header view that contains the user's avatar image. We need to fetch the avatar from the endpoint `api/v1/me` to display at the header view.

## Proof Of Work 📹

![Screenshot 2023-05-10 at 15 48 22](https://github.com/nimblehq/avishek-phong-kmm-ic/assets/22606906/6a36eb49-55de-41df-9e50-65a8830e0658)

