### PR TITLE
[#54] [iOS] [UI] As a user, I can answer a net promoter score (NPS) question

### DIFF
--- a/iosApp/PhongKMMIC.xcodeproj/project.pbxproj
+++ b/iosApp/PhongKMMIC.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		31A4E6E82A121B2200A53B98 /* SurveyQuestionContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31A4E6E72A121B2200A53B98 /* SurveyQuestionContentView.swift */; };
 		31A4E6EB2A13277D00A53B98 /* EmojiAnswerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31A4E6EA2A13277D00A53B98 /* EmojiAnswerView.swift */; };
 		31A4E6ED2A13626700A53B98 /* MultipleChoiceAnswerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31A4E6EC2A13626700A53B98 /* MultipleChoiceAnswerView.swift */; };
+		31A4E6EF2A136D9300A53B98 /* NpsAnswerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31A4E6EE2A136D9300A53B98 /* NpsAnswerView.swift */; };
 		31CCAF3229F1434100262470 /* Screen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31CCAF3129F1434100262470 /* Screen.swift */; };
 		31CCAF3429F1437400262470 /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31CCAF3329F1437400262470 /* AppCoordinator.swift */; };
 		31CCAF3629F1485400262470 /* Transition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31CCAF3529F1485400262470 /* Transition.swift */; };
@@ -184,6 +185,7 @@
 		31A4E6E72A121B2200A53B98 /* SurveyQuestionContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyQuestionContentView.swift; sourceTree = "<group>"; };
 		31A4E6EA2A13277D00A53B98 /* EmojiAnswerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiAnswerView.swift; sourceTree = "<group>"; };
 		31A4E6EC2A13626700A53B98 /* MultipleChoiceAnswerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipleChoiceAnswerView.swift; sourceTree = "<group>"; };
+		31A4E6EE2A136D9300A53B98 /* NpsAnswerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NpsAnswerView.swift; sourceTree = "<group>"; };
 		31CCAF3129F1434100262470 /* Screen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Screen.swift; sourceTree = "<group>"; };
 		31CCAF3329F1437400262470 /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
 		31CCAF3529F1485400262470 /* Transition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Transition.swift; sourceTree = "<group>"; };
@@ -568,6 +570,7 @@
 			children = (
 				31A4E6EA2A13277D00A53B98 /* EmojiAnswerView.swift */,
 				31A4E6EC2A13626700A53B98 /* MultipleChoiceAnswerView.swift */,
+				31A4E6EE2A136D9300A53B98 /* NpsAnswerView.swift */,
 			);
 			path = Answer;
 			sourceTree = "<group>";
@@ -1336,6 +1339,7 @@
 				3160A5E129F281040052C223 /* ViewId.swift in Sources */,
 				3162022429E54E3400ADC0A9 /* KMMICApp.swift in Sources */,
 				3160A5FF29F7E17F0052C223 /* ProgressAnimationView.swift in Sources */,
+				31A4E6EF2A136D9300A53B98 /* NpsAnswerView.swift in Sources */,
 				3186FCAC29F1390F00BA6324 /* SplashViewModel+ObservableObject.swift in Sources */,
 				31A4E6E82A121B2200A53B98 /* SurveyQuestionContentView.swift in Sources */,
 				3160A5F329F51F9F0052C223 /* LaunchArgument.swift in Sources */,

--- a/iosApp/PhongKMMIC/Resources/Localizations/Localizable.strings
+++ b/iosApp/PhongKMMIC/Resources/Localizations/Localizable.strings
@@ -12,6 +12,9 @@
 "home.header.today" = "TODAY";
 "survey.detail.startSurvey" = "Start Survey";
 
+"surveyQuestions.nps.unlike" = "Not at all Likely";
+"surveyQuestions.nps.like" = "Extremely Likely";
+
 "surveyQuestionScreen.exitAlert.message" = "Are you sure you want to quit the survey?";
 "alert.warning.title" = "Warning!";
 "alert.yesButton.title" = "Yes";

--- a/iosApp/PhongKMMIC/Sources/Presentation/Modules/SurveyQuestions/View/Answer/NpsAnswerView.swift
+++ b/iosApp/PhongKMMIC/Sources/Presentation/Modules/SurveyQuestions/View/Answer/NpsAnswerView.swift
@@ -1,0 +1,78 @@
+//
+//  NpsAnswerView.swift
+//  PhongKMMIC
+//
+//  Created by Phong Vo on 16/05/2023.
+//  Copyright © 2023 Nimble. All rights reserved.
+//
+
+import SwiftUI
+
+struct NpsAnswerView: View {
+
+    @State private var selectedIndex: Int?
+
+    var body: some View {
+        VStack(spacing: 16.0) {
+            answersView
+            legendView
+        }
+    }
+
+    private var answersView: some View {
+        HStack(spacing: 0.0) {
+            ForEach(0 ..< 10, id: \.self) { index in
+                Button {
+                    selectedIndex = index
+                    print("selected answer at: \(index)")
+                } label: {
+                    Text("\(index + 1)")
+                        .font(getFontForAnswer(at: index))
+                        .foregroundColor(getTextColorForAnswer(at: index))
+                }
+                .frame(width: 34.0)
+                if index != 10 - 1 {
+                    Divider()
+                        .frame(minWidth: 0.5)
+                        .background(Color.white)
+                }
+            }
+        }
+        .frame(height: 56.0)
+        .cornerRadius(10.0)
+        .overlay(RoundedRectangle(cornerRadius: 10.0).stroke(.white, lineWidth: 1.0))
+        .padding(.horizontal, 20.0)
+    }
+
+    private var legendView: some View {
+        HStack {
+            let leftRangeAlpha = (selectedIndex ?? -1 < 10 / 2) ? 1.0 : 0.5
+            let isInvalidIndex = selectedIndex ?? -1 < 0
+
+            Text(R.string.localizable.surveyQuestionsNpsUnlike())
+                .foregroundColor(Color.white)
+                .opacity(isInvalidIndex ? 0.5 : leftRangeAlpha)
+                .font(.boldBody)
+            Spacer()
+            Text(R.string.localizable.surveyQuestionsNpsLike())
+                .foregroundColor(Color.white)
+                .opacity(isInvalidIndex ? 0.5 : 1.5 - leftRangeAlpha)
+                .font(.boldBody)
+        }
+        .frame(width: 345.5)
+    }
+
+    private func getFontForAnswer(at index: Int) -> Font {
+        if index == selectedIndex {
+            return .boldLarge
+        }
+        return .regularLarge
+    }
+
+    private func getTextColorForAnswer(at index: Int) -> Color {
+        if index == selectedIndex {
+            return .white
+        }
+        return .white.opacity(0.5)
+    }
+}

--- a/iosApp/PhongKMMIC/Sources/Presentation/Modules/SurveyQuestions/View/SurveyQuestionContentView.swift
+++ b/iosApp/PhongKMMIC/Sources/Presentation/Modules/SurveyQuestions/View/SurveyQuestionContentView.swift
@@ -25,7 +25,7 @@ struct SurveyQuestionContentView: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
                 Spacer(minLength: 150.0)
                 // TODO: Replace with correct answer type based on a response from the API
-                MultipleChoiceAnswerView()
+                NpsAnswerView()
             }
         }
     }


### PR DESCRIPTION
- Close #54 

## What happened 👀

- Added `NpsAnswerView` for displaying net promoter score answers.
- Add localized string

## Insight 📝

Create a view allowing a user to see and answer a net promoter score (NPS) question.

## Proof Of Work 📹


![Screenshot 2023-05-16 at 15 28 26](https://github.com/nimblehq/avishek-phong-kmm-ic/assets/22606906/984b75fd-10cf-4863-9c3f-d801982ba46f)
