### PR TITLE
[#12] [KMM] [Backend] As a user, I can see survey's detail

### DIFF
--- a/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/data/remote/datasource/SurveyRemoteDataSource.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/data/remote/datasource/SurveyRemoteDataSource.kt
@@ -20,6 +20,6 @@ class SurveyRemoteDataSourceImpl(private val apiClient: ApiClient) : SurveyRemot
     }
 
     override fun getSurvey(id: String): Flow<SurveyApiModel> {
-        return apiClient.responseBody(Endpoint.SURVEYS + "/${id}", HttpMethod.Get)
+        return apiClient.responseBody(Endpoint.SURVEYS + "/$id", HttpMethod.Get)
     }
 }

--- a/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/data/remote/datasource/SurveyRemoteDataSource.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/data/remote/datasource/SurveyRemoteDataSource.kt
@@ -9,11 +9,17 @@ import kotlinx.coroutines.flow.Flow
 
 interface SurveyRemoteDataSource {
     fun getSurveys(params: GetSurveysQueryParam): Flow<List<SurveyApiModel>>
+
+    fun getSurvey(id: String): Flow<SurveyApiModel>
 }
 
 class SurveyRemoteDataSourceImpl(private val apiClient: ApiClient) : SurveyRemoteDataSource {
 
     override fun getSurveys(params: GetSurveysQueryParam): Flow<List<SurveyApiModel>> {
         return apiClient.responseBodyWithParams(Endpoint.SURVEYS, HttpMethod.Get, params)
+    }
+
+    override fun getSurvey(id: String): Flow<SurveyApiModel> {
+        return apiClient.responseBody(Endpoint.SURVEYS + "/${id}", HttpMethod.Get)
     }
 }

--- a/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/data/remote/model/AnswerApiModel.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/data/remote/model/AnswerApiModel.kt
@@ -1,0 +1,24 @@
+package co.nimblehq.avishek.phong.kmmic.data.remote.model
+
+import co.nimblehq.avishek.phong.kmmic.domain.model.Answer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AnswerApiModel(
+    @SerialName("id")
+    val id: String,
+    @SerialName("text")
+    val text: String?,
+    @SerialName("display_order")
+    val displayOrder: Int,
+    @SerialName("input_mask_placeholder")
+    var inputMaskPlaceholder: String?
+)
+
+fun AnswerApiModel.toAnswer(): Answer = Answer(
+    id = id,
+    text = text,
+    displayOrder = displayOrder,
+    inputMaskPlaceholder = inputMaskPlaceholder
+)

--- a/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/data/remote/model/QuestionApiModel.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/data/remote/model/QuestionApiModel.kt
@@ -1,0 +1,34 @@
+package co.nimblehq.avishek.phong.kmmic.data.remote.model
+
+import co.nimblehq.avishek.phong.kmmic.domain.model.Question
+import co.nimblehq.avishek.phong.kmmic.domain.model.QuestionDisplayType
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class QuestionApiModel(
+    @SerialName("id")
+    val id: String,
+    @SerialName("text")
+    val text: String,
+    @SerialName("display_order")
+    val displayOrder: Int,
+    @SerialName("display_type")
+    val displayType: String,
+    @SerialName("pick")
+    val pick: String,
+    @SerialName("cover_image_url")
+    val coverImageUrl: String,
+    @SerialName("answers")
+    val answers: List<AnswerApiModel>
+)
+
+fun QuestionApiModel.toQuestion(): Question = Question(
+    id = id,
+    text = text,
+    displayOrder = displayOrder,
+    displayType = QuestionDisplayType.fromString(displayType),
+    pick = pick,
+    coverImageUrl = coverImageUrl,
+    answers = answers.map { it.toAnswer() }
+)

--- a/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/data/remote/model/SurveyApiModel.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/data/remote/model/SurveyApiModel.kt
@@ -19,14 +19,17 @@ data class SurveyApiModel(
     val isActive: Boolean,
     @SerialName("cover_image_url")
     val coverImageUrl: String,
+    @SerialName("questions")
+    val questions: List<QuestionApiModel>? = null
 )
 
 fun SurveyApiModel.toSurvey() = Survey(
-    id,
-    title,
-    description,
-    isActive,
-    coverImageUrl
+    id = id,
+    title = title,
+    description = description,
+    isActive = isActive,
+    coverImageUrl = coverImageUrl,
+    questions = questions?.map { it.toQuestion() }
 )
 
 fun SurveyApiModel.toSurveyRealmObject() = SurveyRealmObject(

--- a/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/data/repository/SurveyRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/data/repository/SurveyRepositoryImpl.kt
@@ -11,6 +11,7 @@ import co.nimblehq.avishek.phong.kmmic.domain.repository.SurveyRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.last
+import kotlinx.coroutines.flow.map
 
 private const val FIRST_PAGE_NUMBER = 1
 
@@ -44,5 +45,9 @@ class SurveyRepositoryImpl(
 
             surveyLocalDataSource.saveSurveys(apiSurveys.map { it.toSurveyRealmObject() })
         }
+    }
+
+    override fun getSurvey(id: String): Flow<Survey> {
+        return surveyRemoteDataSource.getSurvey(id).map { it.toSurvey() }
     }
 }

--- a/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/di/module/UseCaseModule.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/di/module/UseCaseModule.kt
@@ -10,5 +10,6 @@ val useCaseModule = module {
     singleOf(::LogInUseCaseImpl) bind LogInUseCase::class
     singleOf(::GetSurveysUseCaseImpl) bind GetSurveysUseCase::class
     singleOf(::GetUserProfileUseCaseImpl) bind GetUserProfileUseCase::class
+    singleOf(::GetSurveyDetailUseCaseImpl) bind GetSurveyDetailUseCase:: class
     singleOf(::GetAppVersionUseCaseImpl) bind GetAppVersionUseCase::class
 }

--- a/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/domain/model/Answer.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/domain/model/Answer.kt
@@ -1,0 +1,22 @@
+package co.nimblehq.avishek.phong.kmmic.domain.model
+
+interface Answerable {
+
+    val id: String
+    val content: String?
+    val placeholder: String?
+}
+
+data class Answer(
+    override val id: String,
+    val text: String?,
+    val displayOrder: Int,
+    var inputMaskPlaceholder: String?
+) : Answerable {
+
+    override val content: String?
+        get() = text
+
+    override val placeholder: String?
+        get() = inputMaskPlaceholder
+}

--- a/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/domain/model/Answer.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/domain/model/Answer.kt
@@ -1,7 +1,6 @@
 package co.nimblehq.avishek.phong.kmmic.domain.model
 
 interface Answerable {
-
     val id: String
     val content: String?
     val placeholder: String?

--- a/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/domain/model/Question.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/domain/model/Question.kt
@@ -1,0 +1,40 @@
+package co.nimblehq.avishek.phong.kmmic.domain.model
+
+enum class QuestionDisplayType {
+    INTRO,
+    STAR,
+    HEART,
+    SMILEY,
+    CHOICE,
+    NPS,
+    TEXTAREA,
+    TEXTFIELD,
+    DROPDOWN,
+    OUTRO,
+    UNKNOWN;
+
+    companion object {
+        fun fromString(value: String): QuestionDisplayType {
+            return try {
+                QuestionDisplayType.valueOf(value)
+            } catch(exc: IllegalArgumentException) {
+                UNKNOWN
+            } catch (exc: NullPointerException) {
+                UNKNOWN
+            }
+        }
+    }
+}
+
+data class Question(
+    val id: String,
+    val text: String,
+    val displayOrder: Int,
+    val displayType: QuestionDisplayType,
+    val pick: String,
+    val coverImageUrl: String,
+    val answers: List<Answer>
+) {
+    val sortedAnswers: List<Answer>
+        get() = answers.sortedBy { it.displayOrder }
+}

--- a/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/domain/model/Question.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/domain/model/Question.kt
@@ -17,7 +17,7 @@ enum class QuestionDisplayType {
         fun fromString(value: String): QuestionDisplayType {
             return try {
                 QuestionDisplayType.valueOf(value)
-            } catch(exc: IllegalArgumentException) {
+            } catch (exc: IllegalArgumentException) {
                 UNKNOWN
             } catch (exc: NullPointerException) {
                 UNKNOWN

--- a/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/domain/model/Survey.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/domain/model/Survey.kt
@@ -5,5 +5,6 @@ data class Survey (
     val title: String,
     val description: String,
     val isActive: Boolean,
-    val coverImageUrl: String
+    val coverImageUrl: String,
+    val questions: List<Question>? = null
 )

--- a/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/domain/repository/SurveyRepository.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/domain/repository/SurveyRepository.kt
@@ -5,4 +5,5 @@ import kotlinx.coroutines.flow.Flow
 
 interface SurveyRepository {
     fun getSurveys(pageNumber: Int, pageSize: Int, isForceLatestData: Boolean): Flow<List<Survey>>
+    fun getSurvey(id: String): Flow<Survey>
 }

--- a/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/domain/usecase/GetSurveyDetailUseCase.kt
+++ b/shared/src/commonMain/kotlin/co/nimblehq/avishek/phong/kmmic/domain/usecase/GetSurveyDetailUseCase.kt
@@ -1,0 +1,18 @@
+package co.nimblehq.avishek.phong.kmmic.domain.usecase
+
+import co.nimblehq.avishek.phong.kmmic.domain.model.Survey
+import co.nimblehq.avishek.phong.kmmic.domain.repository.SurveyRepository
+import kotlinx.coroutines.flow.Flow
+
+interface GetSurveyDetailUseCase {
+    operator fun invoke(id: String): Flow<Survey>
+}
+
+class GetSurveyDetailUseCaseImpl(
+    private val surveyRepository: SurveyRepository
+) : GetSurveyDetailUseCase {
+
+    override operator fun invoke(id: String): Flow<Survey> {
+        return surveyRepository.getSurvey(id)
+    }
+}

--- a/shared/src/commonTest/kotlin/co/nimblehq/avishek/phong/kmmic/data.repository/SurveyRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/co/nimblehq/avishek/phong/kmmic/data.repository/SurveyRepositoryTest.kt
@@ -151,10 +151,7 @@ class SurveyRepositoryTest {
                 .whenInvokedWith(any())
                 .thenReturn(flow { emit(MockUtil.mockSurveyApiModel) })
 
-            repository.getSurvey("id").test {
-                this.awaitItem() shouldBe MockUtil.mockSurveyApiModel.toSurvey()
-                this.awaitComplete()
-            }
+            repository.getSurvey("id").first() shouldBe MockUtil.mockSurveyApiModel.toSurvey()
         }
 
     @Test

--- a/shared/src/commonTest/kotlin/co/nimblehq/avishek/phong/kmmic/data.repository/SurveyRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/co/nimblehq/avishek/phong/kmmic/data.repository/SurveyRepositoryTest.kt
@@ -142,4 +142,31 @@ class SurveyRepositoryTest {
                 this.awaitError().message shouldBe MockUtil.mockThrowable.message
             }
         }
+
+    @Test
+    fun `when get detail survey is succeeded, it returns survey`() =
+        runTest {
+            given(mockSurveyRemoteDataSource)
+                .function(mockSurveyRemoteDataSource::getSurvey)
+                .whenInvokedWith(any())
+                .thenReturn(flow { emit(MockUtil.mockSurveyApiModel) })
+
+            repository.getSurvey("id").test {
+                this.awaitItem() shouldBe MockUtil.mockSurveyApiModel.toSurvey()
+                this.awaitComplete()
+            }
+        }
+
+    @Test
+    fun `when get detail survey is failed, it returns error`() =
+        runTest {
+            given(mockSurveyRemoteDataSource)
+                .function(mockSurveyRemoteDataSource::getSurvey)
+                .whenInvokedWith(any())
+                .thenReturn(flow { throw MockUtil.mockThrowable })
+
+            repository.getSurvey("id").test {
+                this.awaitError().message shouldBe MockUtil.mockThrowable.message
+            }
+        }
 }

--- a/shared/src/commonTest/kotlin/co/nimblehq/avishek/phong/kmmic/domain.usecase/GetSurveyDetailUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/co/nimblehq/avishek/phong/kmmic/domain.usecase/GetSurveyDetailUseCaseTest.kt
@@ -1,0 +1,63 @@
+package co.nimblehq.avishek.phong.kmmic.domain.usecase
+
+import co.nimblehq.avishek.phong.kmmic.data.remote.model.toSurvey
+import co.nimblehq.avishek.phong.kmmic.domain.repository.SurveyRepository
+import co.nimblehq.avishek.phong.kmmic.helper.MockUtil
+import io.kotest.matchers.shouldBe
+import io.mockative.Mock
+import io.mockative.any
+import io.mockative.classOf
+import io.mockative.given
+import io.mockative.mock
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+@ExperimentalCoroutinesApi
+class GetSurveyDetailUseCaseTest {
+
+    @Mock
+    private val mockRepository = mock(classOf<SurveyRepository>())
+
+    private lateinit var useCase: GetSurveyDetailUseCase
+
+    @BeforeTest
+    fun setUp() {
+        useCase = GetSurveyDetailUseCaseImpl(mockRepository)
+    }
+
+    @Test
+    fun `when getSurvey is called successfully, it returns a survey`() = runTest {
+        given(mockRepository)
+            .function(mockRepository::getSurvey)
+            .whenInvokedWith(any())
+            .thenReturn(flowOf(MockUtil.mockSurveyApiModel.toSurvey()))
+
+        useCase("survey_id").collect {
+            it shouldBe MockUtil.mockSurveyApiModel.toSurvey()
+        }
+    }
+
+    @Test
+    fun `when getSurvey is called but returns an error, it returns an error`() = runTest {
+        given(mockRepository)
+            .function(mockRepository::getSurvey)
+            .whenInvokedWith(any())
+            .thenReturn(
+                flow {
+                    throw MockUtil.mockThrowable
+                }
+            )
+
+        useCase("survey_id")
+            .catch {
+                it.message shouldBe MockUtil.mockThrowable.message
+            }
+            .collect()
+    }
+}

--- a/shared/src/commonTest/kotlin/co/nimblehq/avishek/phong/kmmic/domain.usecase/GetSurveyDetailUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/co/nimblehq/avishek/phong/kmmic/domain.usecase/GetSurveyDetailUseCaseTest.kt
@@ -12,6 +12,7 @@ import io.mockative.mock
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
@@ -23,7 +24,7 @@ class GetSurveyDetailUseCaseTest {
 
     @Mock
     private val mockRepository = mock(classOf<SurveyRepository>())
-
+    private val expectedSurvey = MockUtil.mockSurveyApiModel.toSurvey()
     private lateinit var useCase: GetSurveyDetailUseCase
 
     @BeforeTest
@@ -36,11 +37,9 @@ class GetSurveyDetailUseCaseTest {
         given(mockRepository)
             .function(mockRepository::getSurvey)
             .whenInvokedWith(any())
-            .thenReturn(flowOf(MockUtil.mockSurveyApiModel.toSurvey()))
+            .thenReturn(flowOf(expectedSurvey))
 
-        useCase("survey_id").collect {
-            it shouldBe MockUtil.mockSurveyApiModel.toSurvey()
-        }
+        useCase("survey_id").first() shouldBe expectedSurvey
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/co/nimblehq/avishek/phong/kmmic/helper/MockUtil.kt
+++ b/shared/src/commonTest/kotlin/co/nimblehq/avishek/phong/kmmic/helper/MockUtil.kt
@@ -1,5 +1,6 @@
 package co.nimblehq.avishek.phong.kmmic.helper
 
+import co.nimblehq.avishek.phong.kmmic.data.remote.model.QuestionApiModel
 import co.nimblehq.avishek.phong.kmmic.data.remote.model.SurveyApiModel
 import co.nimblehq.avishek.phong.kmmic.data.remote.model.UserApiModel
 import co.nimblehq.avishek.phong.kmmic.domain.model.Survey
@@ -33,6 +34,17 @@ object MockUtil {
         "description",
         true,
         "coverImageUrl",
+        listOf(
+            QuestionApiModel(
+                id = "id",
+                text = "text",
+                displayOrder = 0,
+                displayType = "intro",
+                pick = "pick",
+                coverImageUrl = "coverImageUrl",
+                answers = emptyList()
+            )
+        )
     )
 
     val mockUser = User(


### PR DESCRIPTION
- Close #12 

## What happened 👀

- Add new function to `SurveyRemoteDateSource` for fetching survey's detail by its ID.
- Add `GetSurveyDetailUseCase`
- Add `QuestionApiModel` and `AnswerApiModel`
- Add new property with type `QuestionApiModel` to `SurveyApiModel`
- Add UT
## Insight 📝

Create a use case for fetching Survey's detail by its ID. 

## Proof Of Work 📹


![Screenshot 2023-05-17 at 13 30 49](https://github.com/nimblehq/avishek-phong-kmm-ic/assets/22606906/4c886bfd-d6cb-44e6-8ee5-dd8f9e90d319)
