### PR TITLE
[#53] [Android] [UI] As a user, I can answer a question with multiple forms

### DIFF
--- a/androidApp/src/main/java/co/nimblehq/avishek/phong/kmmic/android/ui/screen/surveydetail/SurveyDetailPreviewParameterProvider.kt
+++ b/androidApp/src/main/java/co/nimblehq/avishek/phong/kmmic/android/ui/screen/surveydetail/SurveyDetailPreviewParameterProvider.kt
@@ -116,6 +116,33 @@ class SurveyDetailScreenPreviewParameterProvider :
                     )
                 )
             )
+        ),
+        Params(
+            isLoading = false,
+            survey = SurveyUiModel(
+                id = "1",
+                title = "Scarlett Bangkok",
+                description = "We'd love to hear from you!",
+                imageUrl = "https://dhdbhh0jsld0o.cloudfront.net/m/1ea51560991bcb7d00d0_",
+                questionUiModels = listOf(
+                    QuestionUiModel(
+                        id = "1",
+                        step = "1/1",
+                        displayOrder = 1,
+                        questionTitle = "How fulfilled did you feel during this WFH period?",
+                        displayType = TEXTFIELD,
+                        answers = List(5) {
+                            SurveyAnswerUiModel(
+                                id = (it + 1).toString(),
+                                text = "Text ${it + 1}",
+                                displayOrder = it,
+                                placeholder = "Your thoughts"
+                            )
+                        },
+                        userInputs = emptySet()
+                    )
+                )
+            )
         )
     )
 

--- a/androidApp/src/main/java/co/nimblehq/avishek/phong/kmmic/android/ui/screen/surveydetail/SurveyQuestionContent.kt
+++ b/androidApp/src/main/java/co/nimblehq/avishek/phong/kmmic/android/ui/screen/surveydetail/SurveyQuestionContent.kt
@@ -186,6 +186,10 @@ private fun AnswerContent(
                     .padding(horizontal = 24.dp)
                     .heightIn(168.dp)
             )
+            TEXTFIELD -> TextFields(
+                surveyAnswerUiModels = questionUiModel.answers,
+                modifier = modifier.padding(horizontal = 24.dp)
+            )
             else -> Unit
         }
     }

--- a/androidApp/src/main/java/co/nimblehq/avishek/phong/kmmic/android/ui/screen/surveydetail/TextFields.kt
+++ b/androidApp/src/main/java/co/nimblehq/avishek/phong/kmmic/android/ui/screen/surveydetail/TextFields.kt
@@ -9,12 +9,14 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import co.nimblehq.avishek.phong.kmmic.android.ui.common.PrimaryTextField
+import co.nimblehq.avishek.phong.kmmic.android.ui.theme.ApplicationTheme
+import co.nimblehq.avishek.phong.kmmic.domain.model.QuestionDisplayType.TEXTFIELD
 import co.nimblehq.avishek.phong.kmmic.presentation.uimodel.SurveyAnswerUiModel
 
 @Composable
 fun TextFields(
     surveyAnswerUiModels: List<SurveyAnswerUiModel>,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     LazyColumn(
         verticalArrangement = Arrangement.spacedBy(16.dp),
@@ -37,10 +39,17 @@ fun TextFields(
 
 @Preview
 @Composable
-fun TextFieldPreview(
-    @PreviewParameter(SurveyDetailScreenPreviewParameterProvider::class) params: SurveyDetailScreenPreviewParameterProvider.Params
-) {
-    TextFields(
-        surveyAnswerUiModels = params.survey.questionUiModels[0].answers
-    )
+fun TextFieldPreview() {
+    ApplicationTheme {
+        TextFields(
+            surveyAnswerUiModels = List(5) {
+                SurveyAnswerUiModel(
+                    id = (it + 1).toString(),
+                    text = "Text ${it + 1}",
+                    displayOrder = it,
+                    placeholder = "Your thoughts"
+                )
+            }
+        )
+    }
 }

--- a/androidApp/src/main/java/co/nimblehq/avishek/phong/kmmic/android/ui/screen/surveydetail/TextFields.kt
+++ b/androidApp/src/main/java/co/nimblehq/avishek/phong/kmmic/android/ui/screen/surveydetail/TextFields.kt
@@ -1,0 +1,46 @@
+package co.nimblehq.avishek.phong.kmmic.android.ui.screen.surveydetail
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import co.nimblehq.avishek.phong.kmmic.android.ui.common.PrimaryTextField
+import co.nimblehq.avishek.phong.kmmic.presentation.uimodel.SurveyAnswerUiModel
+
+@Composable
+fun TextFields(
+    surveyAnswerUiModels: List<SurveyAnswerUiModel>,
+    modifier: Modifier = Modifier
+) {
+    LazyColumn(
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+        modifier = modifier
+    ) {
+        items(surveyAnswerUiModels.size) { index ->
+            var value by remember { mutableStateOf("") }
+
+            PrimaryTextField(
+                value = value,
+                onValueChange = {
+                    value = it
+                },
+                placeholder = surveyAnswerUiModels[index].placeholder.orEmpty(),
+                imeAction = if (index == surveyAnswerUiModels.lastIndex) ImeAction.Done else ImeAction.Next
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+fun TextFieldPreview(
+    @PreviewParameter(SurveyDetailScreenPreviewParameterProvider::class) params: SurveyDetailScreenPreviewParameterProvider.Params
+) {
+    TextFields(
+        surveyAnswerUiModels = params.survey.questionUiModels[0].answers
+    )
+}


### PR DESCRIPTION
- Close #53 

## What happened 👀

- Show multiple forms answer when `question`'s pick is none and `display_type` is `textfield`.

## Insight 📝

Added a new composable for multiple text areas with single line input.

## Proof Of Work 📹

<img width="332" alt="image" src="https://github.com/nimblehq/avishek-phong-kmm-ic/assets/8093908/866d39a4-5cce-47b9-8ca8-8116f5783bf5">
