### PR TITLE
[Chore] bump app version to 0.7.0

### DIFF
--- a/iosApp/PhongKMMIC.xcodeproj/project.pbxproj
+++ b/iosApp/PhongKMMIC.xcodeproj/project.pbxproj
@@ -1407,7 +1407,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.6.0;
+				MARKETING_VERSION = 0.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "${PRODUCT_BUNDLE_IDENTIFIER}";
 				PRODUCT_NAME = PhongKMMIC;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1750,7 +1750,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.6.0;
+				MARKETING_VERSION = 0.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "${PRODUCT_BUNDLE_IDENTIFIER}";
 				PRODUCT_NAME = PhongKMMIC;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1830,7 +1830,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.6.0;
+				MARKETING_VERSION = 0.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "${PRODUCT_BUNDLE_IDENTIFIER}";
 				PRODUCT_NAME = PhongKMMIC;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1862,7 +1862,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.6.0;
+				MARKETING_VERSION = 0.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "${PRODUCT_BUNDLE_IDENTIFIER}";
 				PRODUCT_NAME = PhongKMMIC;
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
- Close #

## What happened 👀

- Bump app's marketing version from 0.6.0 to 0.7.0
## Insight 📝

After releasing the version 0.6.0, we move to the next version 0.7.0

## Proof Of Work 📹

![Screenshot 2023-05-22 at 16 40 16](https://github.com/nimblehq/avishek-phong-kmm-ic/assets/22606906/422fce08-7b40-4b5e-b155-411b5a3c6497)

