### PR TITLE
[#59] [Android] [Integrate] As a user, I can see the thank you screen

### DIFF
--- a/androidApp/src/main/java/co/nimblehq/avishek/phong/kmmic/android/ui/screen/thankyou/ThankYouScreen.kt
+++ b/androidApp/src/main/java/co/nimblehq/avishek/phong/kmmic/android/ui/screen/thankyou/ThankYouScreen.kt
@@ -39,15 +39,14 @@ fun ThankYouScreen(
     ) {
         Column(
             verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier
                 .fillMaxSize()
                 .padding(horizontal = 20.dp)
         ) {
             LottieAnimation(
                 composition = composition,
-                modifier = Modifier
-                    .size(200.dp)
-                    .align(Alignment.CenterHorizontally)
+                modifier = Modifier.size(200.dp)
             )
             Text(
                 text = stringResource(R.string.thank_you_message),

--- a/androidApp/src/main/java/co/nimblehq/avishek/phong/kmmic/android/ui/screen/thankyou/ThankYouScreen.kt
+++ b/androidApp/src/main/java/co/nimblehq/avishek/phong/kmmic/android/ui/screen/thankyou/ThankYouScreen.kt
@@ -1,10 +1,11 @@
 package co.nimblehq.avishek.phong.kmmic.android.ui.screen.thankyou
 
+import androidx.compose.animation.*
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -15,6 +16,9 @@ import androidx.compose.ui.unit.dp
 import co.nimblehq.avishek.phong.kmmic.android.R
 import co.nimblehq.avishek.phong.kmmic.android.ui.theme.ApplicationTheme
 import com.airbnb.lottie.compose.*
+import kotlinx.coroutines.delay
+
+const val FadeAnimationDurationInMillis = 500
 
 @Composable
 fun ThankYouScreen(
@@ -22,29 +26,44 @@ fun ThankYouScreen(
 ) {
     val composition by rememberLottieComposition(LottieCompositionSpec.RawRes(R.raw.thank_you))
     val progress by animateLottieCompositionAsState(composition)
+    var shouldShowContent by remember { mutableStateOf(true) }
 
-    Column(
-        verticalArrangement = Arrangement.Center,
+    AnimatedVisibility(
+        visible = shouldShowContent,
+        enter = fadeIn(animationSpec = tween(FadeAnimationDurationInMillis)),
+        exit = fadeOut(animationSpec = tween(FadeAnimationDurationInMillis)),
         modifier = Modifier
             .fillMaxSize()
-            .padding(horizontal = 20.dp)
+            .statusBarsPadding()
+            .navigationBarsPadding()
     ) {
-        LottieAnimation(
-            composition = composition,
+        Column(
+            verticalArrangement = Arrangement.Center,
             modifier = Modifier
-                .size(200.dp)
-                .align(Alignment.CenterHorizontally)
-        )
-        Text(
-            text = stringResource(R.string.thank_you_message),
-            color = Color.White,
-            style = MaterialTheme.typography.h5,
-            textAlign = TextAlign.Center
-        )
+                .fillMaxSize()
+                .padding(horizontal = 20.dp)
+        ) {
+            LottieAnimation(
+                composition = composition,
+                modifier = Modifier
+                    .size(200.dp)
+                    .align(Alignment.CenterHorizontally)
+            )
+            Text(
+                text = stringResource(R.string.thank_you_message),
+                color = Color.White,
+                style = MaterialTheme.typography.h5,
+                textAlign = TextAlign.Center
+            )
+        }
     }
 
-    if (progress == 1f) {
-        onComplete()
+    LaunchedEffect(progress) {
+        if (progress == 1f) {
+            shouldShowContent = false
+            delay(FadeAnimationDurationInMillis.toLong())
+            onComplete()
+        }
     }
 }
 

--- a/androidApp/src/test/java/co/nimblehq/avishek/phong/kmmic/android/ui/screen/thankyou/ThankYouScreenTest.kt
+++ b/androidApp/src/test/java/co/nimblehq/avishek/phong/kmmic/android/ui/screen/thankyou/ThankYouScreenTest.kt
@@ -1,0 +1,53 @@
+package co.nimblehq.avishek.phong.kmmic.android.ui.screen.thankyou
+
+import android.content.Context
+import androidx.compose.runtime.*
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import co.nimblehq.avishek.phong.kmmic.android.R
+import co.nimblehq.avishek.phong.kmmic.android.ui.theme.ApplicationTheme
+import org.junit.*
+import org.junit.runner.RunWith
+import org.koin.core.context.stopKoin
+
+@RunWith(AndroidJUnit4::class)
+class ThankYouScreenTest {
+
+    @get:Rule
+    val composeRule: ComposeContentTestRule = createComposeRule()
+
+    private val context: Context = InstrumentationRegistry.getInstrumentation().targetContext
+
+    @After
+    fun tearDown() {
+        stopKoin()
+    }
+
+    @Test
+    fun `when entering the Thank You screen, it displays the UI elements accordingly`() {
+        composeRule.mainClock.autoAdvance = false
+        initComposable {
+            waitForAnimationEnd()
+
+            onNodeWithText(context.getString(R.string.thank_you_message)).assertIsDisplayed()
+        }
+    }
+
+    private fun initComposable(testBody: ComposeContentTestRule.() -> Unit) {
+        composeRule.setContent {
+            ApplicationTheme() {
+                ThankYouScreen(
+                    onComplete = {}
+                )
+            }
+        }
+        testBody(composeRule)
+    }
+
+    private fun ComposeContentTestRule.waitForAnimationEnd() {
+        mainClock.advanceTimeBy(FadeAnimationDurationInMillis.toLong())
+    }
+}


### PR DESCRIPTION
- Close #59 

## What happened 👀

- Show the thank you screen for 1 second, then navigate the user back to the Home screen.
- The white check mark and thank you message will be shown with fade in animation.

## Insight 📝

I couldn't find any easy way to animate the background of the **Thank You** screen to fade out/dissolve into the previous screen. Any idea would be appreciated.

## Proof Of Work 📹

https://github.com/nimblehq/avishek-phong-kmm-ic/assets/8093908/2b465953-da98-4e3d-93ca-17dd949df5c6


