### PR TITLE
[#140] [Android] [Integrate] Show confirmation dialog before closing …

### DIFF
--- a/androidApp/src/main/java/co/nimblehq/avishek/phong/kmmic/android/ui/common/AlertDialog.kt
+++ b/androidApp/src/main/java/co/nimblehq/avishek/phong/kmmic/android/ui/common/AlertDialog.kt
@@ -1,6 +1,6 @@
 package co.nimblehq.avishek.phong.kmmic.android.ui.common
 
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
 import androidx.compose.material.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -32,11 +32,66 @@ fun AlertDialog(
     )
 }
 
+@Composable
+fun AlertDialog(
+    title: String,
+    message: String,
+    onYesClick: () -> Unit,
+    onCancelClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    AlertDialog(
+        title = {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.h6
+            )
+        },
+        text = { Text(text = message) },
+        buttons = {
+            Row(
+                horizontalArrangement = Arrangement.End,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .wrapContentHeight()
+            ) {
+                TextButton(
+                    onClick = onCancelClick
+                ) {
+                    Text(
+                        text = stringResource(id = R.string.cancel)
+                    )
+                }
+                TextButton(
+                    onClick = onYesClick
+                ) {
+                    Text(
+                        text = stringResource(id = R.string.yes)
+                    )
+                }
+            }
+        },
+        onDismissRequest = {},
+        modifier = modifier.padding(horizontal = 8.dp)
+    )
+}
+
 @Preview(showBackground = true)
 @Composable
 fun AlertDialogPreview() {
     AlertDialog(
         message = "Message",
         onDismissRequest = {}
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+fun AlertDialogMultiButtonsPreview() {
+    AlertDialog(
+        title = "Title",
+        message = "Message",
+        onYesClick = {},
+        onCancelClick = {}
     )
 }

--- a/androidApp/src/main/java/co/nimblehq/avishek/phong/kmmic/android/ui/screen/surveydetail/SurveyDetailScreen.kt
+++ b/androidApp/src/main/java/co/nimblehq/avishek/phong/kmmic/android/ui/screen/surveydetail/SurveyDetailScreen.kt
@@ -6,9 +6,12 @@ import androidx.compose.foundation.pager.*
 import androidx.compose.material.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import co.nimblehq.avishek.phong.kmmic.android.R
+import co.nimblehq.avishek.phong.kmmic.android.ui.common.AlertDialog
 import co.nimblehq.avishek.phong.kmmic.android.ui.theme.ApplicationTheme
 import co.nimblehq.avishek.phong.kmmic.domain.model.QuestionDisplayType.INTRO
 import co.nimblehq.avishek.phong.kmmic.presentation.module.HomeViewModel
@@ -41,6 +44,7 @@ fun SurveyDetailScreen(
     val surveyWithoutIntro = surveyDetailViewState.survey?.run {
         copy(questions = questions?.filter { it.displayType != INTRO })
     }
+    var shouldShowExitConfirmationDialog by remember { mutableStateOf(false) }
 
     LaunchedEffect(Unit) {
         surveyDetailViewModel.fetchSurveyDetail(surveyId)
@@ -65,6 +69,9 @@ fun SurveyDetailScreen(
         onStartSurveyClick = {
             shouldShowSurveyQuestionContent = true
         },
+        onCloseClick = {
+            shouldShowExitConfirmationDialog = true
+        },
         onAnswersSubmitted = onAnswersSubmitted
     )
 
@@ -73,6 +80,17 @@ fun SurveyDetailScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .wrapContentSize()
+        )
+    }
+
+    if (shouldShowExitConfirmationDialog) {
+        AlertDialog(
+            title = LocalContext.current.getString(R.string.warning),
+            message = LocalContext.current.getString(R.string.quit_survey_message),
+            onYesClick = onBackClick,
+            onCancelClick = {
+                shouldShowExitConfirmationDialog = false
+            }
         )
     }
 }
@@ -85,6 +103,7 @@ fun SurveyDetailContent(
     shouldShowSurveyQuestionContent: Boolean,
     onBackClick: () -> Unit,
     onStartSurveyClick: () -> Unit,
+    onCloseClick: () -> Unit,
     onAnswersSubmitted: () -> Unit,
     imageScale: Float,
 ) {
@@ -103,7 +122,7 @@ fun SurveyDetailContent(
         SurveyQuestionContent(
             backgroundImageUrl = surveyUiModel?.largeImageUrl.orEmpty(),
             questionUiModels = questionUiModels,
-            onCloseClick = {},
+            onCloseClick = onCloseClick,
             onSubmitClick = {
                 //TODO: invoke after the submission is successful in the integrate task
                 onAnswersSubmitted()
@@ -131,6 +150,7 @@ fun SurveyDetailScreenStartPagePreview(
                 shouldShowSurveyQuestionContent = false,
                 onBackClick = {},
                 onStartSurveyClick = {},
+                onCloseClick = {},
                 onAnswersSubmitted = {},
                 imageScale = FinalImageScale
             )
@@ -156,6 +176,7 @@ fun SurveyDetailScreenQuestionPagePreview(
                 shouldShowSurveyQuestionContent = true,
                 onBackClick = {},
                 onStartSurveyClick = {},
+                onCloseClick = {},
                 onAnswersSubmitted = { },
                 imageScale = FinalImageScale
             )

--- a/androidApp/src/main/java/co/nimblehq/avishek/phong/kmmic/android/ui/screen/surveydetail/SurveyQuestionContent.kt
+++ b/androidApp/src/main/java/co/nimblehq/avishek/phong/kmmic/android/ui/screen/surveydetail/SurveyQuestionContent.kt
@@ -1,5 +1,6 @@
 package co.nimblehq.avishek.phong.kmmic.android.ui.screen.surveydetail
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.*
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.pager.HorizontalPager
@@ -132,6 +133,10 @@ fun SurveyQuestionContent(
                     .wrapContentWidth()
             )
         }
+    }
+
+    BackHandler(true) {
+        onCloseClick()
     }
 }
 

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -5,7 +5,6 @@
     <string name="login_password">Password</string>
     <string name="login_forgot">Forgot?</string>
     <string name="login_button">Log in</string>
-    <string name="ok">OK</string>
     <string name="home_today">Today</string>
     <string name="home_logout">Logout</string>
     <string name="survey_detail_start">Start Survey</string>
@@ -13,4 +12,9 @@
     <string name="nps_not_ikely">Not at all Likely</string>
     <string name="nps_likely">Extremely Likely</string>
     <string name="thank_you_message">Thanks for taking the survey.</string>
+    <string name="ok">OK</string>
+    <string name="yes">Yes</string>
+    <string name="cancel">Cancel</string>
+    <string name="warning">Warning!</string>
+    <string name="quit_survey_message">Are you sure you want to quit the survey?</string>
 </resources>


### PR DESCRIPTION
- Close #140 

## What happened 👀

- Show the confirmation dialog (system dialog) when the user taps the close button.
- When "Yes" is pressed, close the survey.
- When "Cancel" is pressed, close the dialog and stay on the survey page.

## Insight 📝

N/A

## Proof Of Work 📹


https://github.com/nimblehq/avishek-phong-kmm-ic/assets/8093908/8db575f1-3906-441e-9300-77a3fad155e7

